### PR TITLE
Fix corrupt initial frames https://github.com/wang-bin/QtAV/issues/70

### DIFF
--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -676,10 +676,12 @@ void AVPlayer::play()
     if (aCodecCtx && audio_thread) {
         qDebug("Starting audio thread...");
         audio_thread->start();
+        audio_thread->waitForReady();
     }
     if (vCodecCtx && video_thread) {
         qDebug("Starting video thread...");
         video_thread->start();
+        video_thread->waitForReady();
     }
     demuxer_thread->start();
     //blockSignals(false);

--- a/src/QtAV/AVThread.h
+++ b/src/QtAV/AVThread.h
@@ -68,6 +68,8 @@ public:
 
     bool isPaused() const;
 
+    void waitForReady();
+
     bool installFilter(Filter *filter, bool lock = true);
     bool uninstallFilter(Filter *filter, bool lock = true);
     const QList<Filter *> &filters() const;

--- a/src/QtAV/private/AVThread_p.h
+++ b/src/QtAV/private/AVThread_p.h
@@ -56,6 +56,7 @@ public:
       , delay(0)
       , filter_context(0)
       , statistics(0)
+      , ready(false)
     {
     }
     //DO NOT delete dec and writer. We do not own them
@@ -77,6 +78,9 @@ public:
     Statistics *statistics; //not obj. Statistics is unique for the player, which is in AVPlayer
     QList<AVOutput*> update_outputs;
     QList<QRunnable*> tasks;
+    QWaitCondition ready_cond;
+    QMutex ready_mutex;
+    bool ready;
 };
 
 } //namespace QtAV


### PR DESCRIPTION
There is a race condition where AVDemuxThread starts queueing packets
before AVThread::resetState is called from VideoThread.
When AVThread::resetState gets called, all collected frames get dropped.

This patch waits on a conditional variable for AVThreads to start properly.
