### PR TITLE
Fixed could not create buffers.

### DIFF
--- a/src/AudioOutputOpenAL.cpp
+++ b/src/AudioOutputOpenAL.cpp
@@ -153,6 +153,10 @@ static ALenum audioFormatToAL(const AudioFormat& fmt)
             }
         }
     }
+    ALCenum err = alGetError();
+    if (err != AL_NO_ERROR) {
+        qWarning("OpenAL audioFormatToAL error: %s", alGetString(err));
+    }
     if (format == 0) {
         qWarning("AudioOutputOpenAL Error: No OpenAL format available for audio data format %s %s."
                  , qPrintable(fmt.sampleFormatName())


### PR DESCRIPTION
(Always check for openal errors after using openal functions.)
Audio playback works on OS-X using OpenAL but still not completely fluid, way better than before though.

Still need to test iOS.
