### PR TITLE
mimic qtmultimedia's mediaObject

### DIFF
--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -56,6 +56,7 @@ class QMLAV_EXPORT QmlAVPlayer : public QObject, public QQmlParserStatus
     Q_PROPERTY(int loops READ loopCount WRITE setLoopCount NOTIFY loopCountChanged)
     Q_PROPERTY(bool seekable READ isSeekable NOTIFY seekableChanged)
     Q_PROPERTY(MediaMetaData *metaData READ metaData CONSTANT)
+    Q_PROPERTY(QObject *mediaObject READ mediaObject)
 
     Q_PROPERTY(ChannelLayout channelLayout READ channelLayout WRITE setChannelLayout NOTIFY channelLayoutChanged)
 
@@ -126,6 +127,7 @@ public:
     void setAutoPlay(bool autoplay);
 
     MediaMetaData *metaData() const;
+    QObject *mediaObject() const;
 
     // "FFmpeg", "CUDA", "DXVA", "VAAPI" etc
     QStringList videoCodecs() const;
@@ -167,6 +169,8 @@ Q_SIGNALS:
     void seekableChanged();
     void videoCodecPriorityChanged();
     void channelLayoutChanged();
+
+    void mediaObjectChanged();
 
 private Q_SLOTS:
     // connect to signals from player

--- a/qml/QmlAVPlayer.cpp
+++ b/qml/QmlAVPlayer.cpp
@@ -64,18 +64,21 @@ QmlAVPlayer::QmlAVPlayer(QObject *parent) :
   , mpPlayer(0)
   , mChannelLayout(ChannelLayoutAuto)
 {
-    mpPlayer = new AVPlayer(this); //in componentComplete()?
+}
+
+void QmlAVPlayer::classBegin()
+{
+    mpPlayer = new AVPlayer(this);
     connect(mpPlayer, SIGNAL(paused(bool)), SLOT(_q_paused(bool)));
     connect(mpPlayer, SIGNAL(started()), SLOT(_q_started()));
     connect(mpPlayer, SIGNAL(stopped()), SLOT(_q_stopped()));
     connect(mpPlayer, SIGNAL(positionChanged(qint64)), SIGNAL(positionChanged()));
 
     mVideoCodecs << "FFmpeg";
-}
 
-void QmlAVPlayer::classBegin()
-{
     m_metaData.reset(new MediaMetaData());
+
+    emit mediaObjectChanged();
 }
 
 void QmlAVPlayer::componentComplete()
@@ -167,6 +170,11 @@ void QmlAVPlayer::setAutoPlay(bool autoplay)
 MediaMetaData* QmlAVPlayer::metaData() const
 {
     return m_metaData.data();
+}
+
+QObject* QmlAVPlayer::mediaObject() const
+{
+    return mpPlayer;
 }
 
 QStringList QmlAVPlayer::videoCodecs() const


### PR DESCRIPTION
signal connections are moved in beginClass() as in qtdeclarativeaudio
(MediaPlayer)
