### PR TITLE
keep ffmpeg timestamp when converting frame

### DIFF
--- a/src/VideoFrame.cpp
+++ b/src/VideoFrame.cpp
@@ -465,6 +465,7 @@ VideoFrame VideoFrameConverter::convert(const VideoFrame &frame, int fffmt) cons
     VideoFrame f(m_cvt->outData(), frame.width(), frame.height(), VideoFormat(fffmt));
     f.setBits(m_cvt->outPlanes());
     f.setBytesPerLine(m_cvt->outLineSizes());
+    f.setTimestamp(frame.timestamp());
     return f;
 }
 


### PR DESCRIPTION
ffmpeg timestamp is lost when calling convert()