### PR TITLE
Change STATICLINK to autodetect the system's prefered library type

### DIFF
--- a/qml/libQmlAV.pro
+++ b/qml/libQmlAV.pro
@@ -17,7 +17,6 @@ QMAKE_MOC_OPTIONS += -Muri=$$URI # not sure what moc does
   }
 }
 #var with '_' can not pass to pri?
-STATICLINK = 0
 PROJECTROOT = $$PWD/..
 !include($$PROJECTROOT/src/libQtAV.pri): error("could not find libQtAV.pri")
 !include(libQmlAV.pri): error("could not find libQmlAV.pri")

--- a/src/libQtAV.pri
+++ b/src/libQtAV.pri
@@ -18,13 +18,13 @@
 #
 ############################## HOW TO ##################################
 # Suppose the library name is XX
-# Usually what you need to change are: staticlink, LIB_VERSION, NAME and DLLDESTDIR.
+# Usually what you need to change are: LIB_VERSION, NAME and DLLDESTDIR.
 # And rename xx-buildlib and LIBXX_PRI_INCLUDED
 # the contents of libXX.pro is:
 #    TEMPLATE = lib
 #    QT -= gui
 #    CONFIG *= xx-buildlib
-#    STATICLINK = 1 #optional. default is 0, i.e. dynamically link
+#    STATICLINK = 1 #optional. default is detected by staticlib in CONFIG
 #    PROJECTROOT = $$PWD/..
 #    include(libXX.pri)
 #    preparePaths($$OUT_PWD/../out)
@@ -34,7 +34,7 @@
 # the content of other pro using this library is:
 #    TEMPLATE = app
 #    PROJECTROOT = $$PWD/..
-#    STATICLINK = 1 #or 0
+#    STATICLINK = 1 #optional. default is detected by staticlib in CONFIG
 #    include(dir_of_XX/libXX.pri)
 #    preparePaths($$OUT_PWD/../out)
 #    HEADERS = ...
@@ -49,8 +49,18 @@ NAME = QtAV
 eval(LIB$$upper($$NAME)_PRI_INCLUDED = 1)
 
 LIB_VERSION = $$QTAV_VERSION #0.x.y may be wrong for dll
-ios: STATICLINK=1
-isEmpty(STATICLINK): STATICLINK = 0  #1 or 0. use static lib or not
+
+# If user haven't supplied STATICLINK, then auto-detect
+isEmpty(STATICLINK) {
+  contains(CONFIG, staticlib) {
+    STATICLINK = 1
+  } else {
+    STATICLINK = 0
+  }
+  # Override for ios. Dynamic link is only supported
+  # in iOS 8.1.
+  ios:STATICLINK = 1
+}
 
 TEMPLATE += fakelib
 PROJECT_TARGETNAME = $$qtLibraryTarget($$NAME)

--- a/src/libQtAV.pro
+++ b/src/libQtAV.pro
@@ -22,7 +22,6 @@ sse2|config_sse2|contains(TARGET_ARCH_SUB, sse2): CONFIG *= sse2 config_simd
 
 #release: DEFINES += QT_NO_DEBUG_OUTPUT
 #var with '_' can not pass to pri?
-STATICLINK = 0
 PROJECTROOT = $$PWD/..
 !include(libQtAV.pri): error("could not find libQtAV.pri")
 preparePaths($$OUT_PWD/../out)

--- a/tools/install_sdk/install_sdk.pro
+++ b/tools/install_sdk/install_sdk.pro
@@ -8,7 +8,6 @@ config_gl {
 }
 #load(qt_module)
 
-STATICLINK = 0
 PROJECTROOT = $$PWD/../..
 include($$PROJECTROOT/common.pri)
 preparePaths($$OUT_PWD/../../out)

--- a/widgets/libQtAVWidgets.pro
+++ b/widgets/libQtAVWidgets.pro
@@ -16,7 +16,6 @@ CONFIG *= qtavwidgets-buildlib
 INCLUDEPATH += $$[QT_INSTALL_HEADERS]
 #release: DEFINES += QT_NO_DEBUG_OUTPUT
 #var with '_' can not pass to pri?
-STATICLINK = 0
 PROJECTROOT = $$PWD/..
 !include($$PROJECTROOT/src/libQtAV.pri): error("could not find libQtAV.pri")
 !include(libQtAVWidgets.pri): error("could not find libQtAVWidgets.pri")


### PR DESCRIPTION
Change STATICLINK to autodetect the system's prefered library type: static or dynamic based on config. This improves ios support

Signed-off-by: Thiago A. Correa <thiago.correa@gmail.com>