### PR TITLE
Fix shader loading when the library is built statically

### DIFF
--- a/src/QtAV_Global.cpp
+++ b/src/QtAV_Global.cpp
@@ -328,3 +328,21 @@ public:
 InitFFmpegLog fflog;
 }
 }
+
+// Initialize Qt Resource System when the library is built
+// statically
+
+static void initResources() {
+    Q_INIT_RESOURCE(shaders);
+    Q_INIT_RESOURCE(QtAV);
+}
+
+namespace {
+    class ResourceLoader {
+    public:
+        ResourceLoader() { initResources(); }
+    };
+    
+    ResourceLoader QtAV_QRCLoader;
+}
+


### PR DESCRIPTION
Fix shader loading when the library is built statically

Signed-off-by: Thiago A. Correa <thiago.correa@gmail.com>