### PR TITLE
ScreenSaver: only use X11 calls if running on proper display

### DIFF
--- a/examples/common/ScreenSaver.cpp
+++ b/examples/common/ScreenSaver.cpp
@@ -126,23 +126,27 @@ ScreenSaver::ScreenSaver()
     interval = 0;
     preferBlanking = 0;
     allowExposures = 0;
-    xlib.setFileName("libX11.so");
-    isX11 = xlib.load();
-    // meego only has libX11.so.6, libX11.so.6.x.x
-    if (!isX11) {
-        xlib.setFileName("libX11.so.6");
-        isX11 = xlib.load();
-    }
-    if (!isX11) {
-        qDebug("open X11 so failed: %s", xlib.errorString().toUtf8().constData());
+    if (qgetenv("DISPLAY").isEmpty()) {
+        isX11 = false;
     } else {
-        XOpenDisplay = (fXOpenDisplay)xlib.resolve("XOpenDisplay");
-        XCloseDisplay = (fXCloseDisplay)xlib.resolve("XCloseDisplay");
-        XSetScreenSaver = (fXSetScreenSaver)xlib.resolve("XSetScreenSaver");
-        XGetScreenSaver = (fXGetScreenSaver)xlib.resolve("XGetScreenSaver");
-        XResetScreenSaver = (fXResetScreenSaver)xlib.resolve("XResetScreenSaver");
+        xlib.setFileName("libX11.so");
+        isX11 = xlib.load();
+        // meego only has libX11.so.6, libX11.so.6.x.x
+        if (!isX11) {
+            xlib.setFileName("libX11.so.6");
+            isX11 = xlib.load();
+        }
+        if (!isX11) {
+            qDebug("open X11 so failed: %s", xlib.errorString().toUtf8().constData());
+        } else {
+            XOpenDisplay = (fXOpenDisplay)xlib.resolve("XOpenDisplay");
+            XCloseDisplay = (fXCloseDisplay)xlib.resolve("XCloseDisplay");
+            XSetScreenSaver = (fXSetScreenSaver)xlib.resolve("XSetScreenSaver");
+            XGetScreenSaver = (fXGetScreenSaver)xlib.resolve("XGetScreenSaver");
+            XResetScreenSaver = (fXResetScreenSaver)xlib.resolve("XResetScreenSaver");
+        }
+        isX11 = XOpenDisplay && XCloseDisplay && XSetScreenSaver && XGetScreenSaver && XResetScreenSaver;
     }
-    isX11 = XOpenDisplay && XCloseDisplay && XSetScreenSaver && XGetScreenSaver && XResetScreenSaver;
 #endif //Q_OS_LINUX
     ssTimerId = 0;
     retrieveState();


### PR DESCRIPTION
In linux there are now more display servers than just X, so we have to deal
with them.