### PR TITLE
Support useWallclockAsTimestamps AVFormat options

### DIFF
--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -70,6 +70,7 @@ class QmlAVPlayer : public QObject, public QQmlParserStatus
     Q_PROPERTY(QStringList videoCodecs READ videoCodecs)
     Q_PROPERTY(QStringList videoCodecPriority READ videoCodecPriority WRITE setVideoCodecPriority NOTIFY videoCodecPriorityChanged)
     Q_PROPERTY(QVariantMap videoCodecOptions READ videoCodecOptions WRITE setVideoCodecOptions NOTIFY videoCodecOptionsChanged)
+    Q_PROPERTY(bool useWallclockAsTimestamps READ useWallclockAsTimestamps WRITE setWallclockAsTimestamps NOTIFY useWallclockAsTimestampsChanged)
     Q_PROPERTY(QtAV::VideoCapture *videoCapture READ videoCapture CONSTANT)
     Q_PROPERTY(int audioTrack READ audioTrack WRITE setAudioTrack NOTIFY audioTrackChanged)
     Q_PROPERTY(QUrl externalAudio READ externalAudio WRITE setExternalAudio NOTIFY externalAudioChanged)
@@ -168,6 +169,9 @@ public:
     QVariantMap videoCodecOptions() const;
     void setVideoCodecOptions(const QVariantMap& value);
 
+	bool useWallclockAsTimestamps() const;
+	void setWallclockAsTimestamps(bool o);
+
     void setAudioChannels(int channels);
     int audioChannels() const;
     void setChannelLayout(ChannelLayout channel);
@@ -229,6 +233,7 @@ Q_SIGNALS:
     void bufferProgressChanged();
     void videoCodecPriorityChanged();
     void videoCodecOptionsChanged();
+    void useWallclockAsTimestampsChanged();
     void channelLayoutChanged();
     void timeoutChanged();
     void abortOnTimeoutChanged();
@@ -257,6 +262,7 @@ private Q_SLOTS:
 private:
     Q_DISABLE_COPY(QmlAVPlayer)
 
+	bool mUseWallclockAsTimestamps;
     bool m_complete;
     bool m_mute;
     bool mAutoPlay;

--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -262,7 +262,7 @@ private Q_SLOTS:
 private:
     Q_DISABLE_COPY(QmlAVPlayer)
 
-	bool mUseWallclockAsTimestamps;
+    bool mUseWallclockAsTimestamps;
     bool m_complete;
     bool m_mute;
     bool mAutoPlay;

--- a/qml/QmlAVPlayer.cpp
+++ b/qml/QmlAVPlayer.cpp
@@ -57,6 +57,7 @@ static inline QVector<VideoDecoderId> VideoDecodersFromNames(const QStringList& 
 
 QmlAVPlayer::QmlAVPlayer(QObject *parent) :
     QObject(parent)
+  , mUseWallclockAsTimestamps(false)
   , m_complete(false)
   , m_mute(false)
   , mAutoPlay(false)
@@ -74,7 +75,6 @@ QmlAVPlayer::QmlAVPlayer(QObject *parent) :
   , m_timeout(30000)
   , m_abort_timeout(true)
   , m_audio_track(0)
-  , mUseWallclockAsTimestamps(false)
 {
     classBegin();
 }
@@ -251,16 +251,21 @@ void QmlAVPlayer::setVideoCodecOptions(const QVariantMap &value)
     // player maybe not ready
 }
 
+bool QmlAVPlayer::useWallclockAsTimestamps() const
+{
+    return mUseWallclockAsTimestamps;
+}
+
 void QmlAVPlayer::setWallclockAsTimestamps(bool o)
 {
     if (mUseWallclockAsTimestamps == o)
         return;
     mUseWallclockAsTimestamps = o;
 
-	QVariantHash opt;
+    QVariantHash opt = mpPlayer->optionsForFormat();
     if (o) {
-	    opt["use_wallclock_as_timestamps"] = 1;
-	}
+        opt["use_wallclock_as_timestamps"] = 1;
+    }
     mpPlayer->setBufferValue(1);
     mpPlayer->setOptionsForFormat(opt);
     emit useWallclockAsTimestampsChanged();

--- a/qml/QmlAVPlayer.cpp
+++ b/qml/QmlAVPlayer.cpp
@@ -74,6 +74,7 @@ QmlAVPlayer::QmlAVPlayer(QObject *parent) :
   , m_timeout(30000)
   , m_abort_timeout(true)
   , m_audio_track(0)
+  , mUseWallclockAsTimestamps(false)
 {
     classBegin();
 }
@@ -248,6 +249,21 @@ void QmlAVPlayer::setVideoCodecOptions(const QVariantMap &value)
     vcodec_opt = value;
     emit videoCodecOptionsChanged();
     // player maybe not ready
+}
+
+void QmlAVPlayer::setWallclockAsTimestamps(bool o)
+{
+    if (mUseWallclockAsTimestamps == o)
+        return;
+    mUseWallclockAsTimestamps = o;
+
+	QVariantHash opt;
+    if (o) {
+	    opt["use_wallclock_as_timestamps"] = 1;
+	}
+    mpPlayer->setBufferValue(1);
+    mpPlayer->setOptionsForFormat(opt);
+    emit useWallclockAsTimestampsChanged();
 }
 
 static AudioFormat::ChannelLayout toAudioFormatChannelLayout(QmlAVPlayer::ChannelLayout ch)

--- a/qml/plugins.qmltypes
+++ b/qml/plugins.qmltypes
@@ -203,6 +203,7 @@ Module {
         Property { name: "videoCodecPriority"; type: "QStringList" }
         Property { name: "videoCodecOptions"; type: "QVariantMap" }
         Property { name: "videoCapture"; type: "QtAV::VideoCapture"; isReadonly: true; isPointer: true }
+        Property { name: "useWallclockAsTimestamps"; type: "bool" }
         Property { name: "audioTrack"; type: "int" }
         Property { name: "externalAudio"; type: "QUrl" }
         Property { name: "internalAudioTracks"; type: "QVariantList"; isReadonly: true }

--- a/src/QtAV/AVEncoder.h
+++ b/src/QtAV/AVEncoder.h
@@ -46,8 +46,6 @@ public:
      */
     void setCodecName(const QString& name);
     QString codecName() const;
-    void setBitRate(int value);
-    int bitRate() const;
     bool open();
     bool close();
     bool isOpen() const;
@@ -59,7 +57,13 @@ public:
      */
     virtual void copyAVCodecContext(void* ctx);
     void* codecContext() const; // TODO: always have a avctx like decoder?
-    // avcodec_open2
+    /*!
+     * \brief setBitRate
+     * Higher bit rate result in better quality.
+     * Default for video: 400000, audio: 64000
+     */
+    void setBitRate(int value);
+    int bitRate() const;
     /*!
      * \brief setOptions
      * 1. If has key "avcodec", it's value (suboption, a hash or map) will be used to set AVCodecContext use av_opt_set and av_dict_set. A value of hash type is ignored.

--- a/src/QtAV/AVMuxer.h
+++ b/src/QtAV/AVMuxer.h
@@ -69,7 +69,8 @@ public:
     bool close();
     bool isOpen() const;
 
-    void copyProperties(VideoEncoder* enc);
+    // TODO: copyAudioContext(void* avctx) for copy encoding without decoding
+    void copyProperties(VideoEncoder* enc); //rename to setEncoder
     void copyProperties(AudioEncoder* enc);
 
     void setOptions(const QVariantHash &dict);

--- a/src/QtAV/AVTranscoder.h
+++ b/src/QtAV/AVTranscoder.h
@@ -23,6 +23,7 @@
 #define QTAV_AVTRANSCODE_H
 
 #include <QtAV/MediaIO.h>
+#include <QtAV/AudioEncoder.h>
 #include <QtAV/VideoEncoder.h>
 
 namespace QtAV {
@@ -71,7 +72,19 @@ public:
      * \return Encoder instance or null if createVideoEncoder failed
      */
     VideoEncoder* videoEncoder() const;
-
+    /*!
+     * \brief createEncoder
+     * Destroy old encoder and create a new one in filter chain. Filter has the ownership.
+     * \param name registered encoder name, for example "FFmpeg"
+     * \return false if failed
+     */
+    bool createAudioEncoder(const QString& name = "FFmpeg");
+    /*!
+     * \brief encoder
+     * Use this to set encoder properties and options
+     * \return Encoder instance or null if createAudioEncoder failed
+     */
+    AudioEncoder* audioEncoder() const;
     /*!
      * \brief isRunning
      * \return true if encoding started
@@ -100,6 +113,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void prepareMuxer();
+    void writeAudio(const QtAV::Packet& packet);
     void writeVideo(const QtAV::Packet& packet);
 
 private:

--- a/src/QtAV/EncodeFilter.h
+++ b/src/QtAV/EncodeFilter.h
@@ -24,9 +24,49 @@
 
 #include <QtAV/Filter.h>
 #include <QtAV/Packet.h>
+#include <QtAV/AudioFrame.h>
 #include <QtAV/VideoFrame.h>
 
 namespace QtAV {
+
+class AudioEncoder;
+class AudioEncodeFilterPrivate;
+class Q_AV_EXPORT AudioEncodeFilter : public AudioFilter
+{
+    Q_OBJECT
+    DPTR_DECLARE_PRIVATE(AudioEncodeFilter)
+public:
+    AudioEncodeFilter(QObject *parent = 0);
+
+    /*!
+     * \brief createEncoder
+     * Destroy old encoder and create a new one. Filter has the ownership.
+     * Encoder will open when encoding first valid frame, and set width/height as frame's.
+     * \param name registered encoder name, for example "FFmpeg"
+     * \return null if failed
+     */
+    AudioEncoder* createEncoder(const QString& name = "FFmpeg");
+    /*!
+     * \brief encoder
+     * Use this to set encoder properties and options
+     * \return Encoder instance or null if createEncoder failed
+     */
+    AudioEncoder* encoder() const;
+    // TODO: async property
+
+Q_SIGNALS:
+    /*!
+     * \brief readyToEncode
+     * Emitted when encoder is open. All parameters are set and muxer can set codec properties now.
+     * close the encoder() to reset and reopen.
+     */
+    void readyToEncode();
+    void frameEncoded(const QtAV::Packet& packet);
+
+protected:
+    virtual void process(Statistics* statistics, AudioFrame* frame = 0) Q_DECL_OVERRIDE;
+    void encode(const AudioFrame& frame = AudioFrame());
+};
 
 class VideoEncoder;
 class VideoEncodeFilterPrivate;

--- a/src/QtAV/VideoEncoder.h
+++ b/src/QtAV/VideoEncoder.h
@@ -47,7 +47,7 @@ public:
     static VideoEncoder* create(VideoEncoderId id);
     /*!
      * \brief create
-     * create a decoder from registered name
+     * create an encoder from registered names
      * \param name can be "FFmpeg". FFmpeg encoder will be created for empty name
      * \return 0 if not registered
      */
@@ -61,6 +61,7 @@ public:
      * \return
      */
     virtual bool encode(const VideoFrame& frame = VideoFrame()) = 0;
+    /// output parameters
     /*!
      * \brief setWidth
      * set the encoded video width. The same as input frame size if value <= 0
@@ -69,15 +70,17 @@ public:
     int width() const;
     void setHeight(int value);
     int height() const;
+    /// TODO: check avctx->supported_framerates. use frame_rate_used
     void setFrameRate(qreal value);
     qreal frameRate() const;
     /*!
      * \brief setPixelFormat
-     * set Format_Invalid (default) to auto
+     * If not set or set to an invalid format, a supported format will be used and pixelFormat() will be that format after open()
      * \param format
      */
     void setPixelFormat(const VideoFormat::PixelFormat format);
     VideoFormat::PixelFormat pixelFormat() const;
+    // TODO: supportedPixelFormats() const;
 Q_SIGNALS:
     void widthChanged();
     void heightChanged();

--- a/src/codec/audio/AudioEncoderFFmpeg.cpp
+++ b/src/codec/audio/AudioEncoderFFmpeg.cpp
@@ -131,6 +131,8 @@ bool AudioEncoderFFmpegPrivate::open()
 
     avctx->bit_rate = bit_rate;
     qDebug() << format_used;
+
+    av_dict_set(&dict, "strict", "-2", 0); //aac, vorbis
     applyOptionsForContext();
     // avctx->frame_size will be set in avcodec_open2
     AV_ENSURE_OK(avcodec_open2(avctx, codec, &dict), false);
@@ -178,7 +180,7 @@ bool AudioEncoderFFmpeg::encode(const AudioFrame &frame)
         const AudioFormat fmt(frame.format());
         f->format = fmt.sampleFormatFFmpeg();
         f->channel_layout = fmt.channelLayoutFFmpeg();
-        f->channels = fmt.channels(); //remove?
+        // f->channels = fmt.channels(); //remove? not availale in libav9
         // must be (not the last frame) exactly frame_size unless CODEC_CAP_VARIABLE_FRAME_SIZE is set (frame_size==0)
         // TODO: mpv use pcmhack for avctx.frame_size==0. can we use input frame.samplesPerChannel?
         f->nb_samples = d.frame_size;


### PR DESCRIPTION
fixed #429 

it has high latency because media source has no timestamp information(mjpeg format, lot of IP Camera and live streaming is using mjpeg), so use_wallclock_as_timestamps can solve this problem.