### PR TITLE
Add useWallclockAsTimerstamps property to AVPlayer

### DIFF
--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -70,6 +70,7 @@ class QmlAVPlayer : public QObject, public QQmlParserStatus
     Q_PROPERTY(QStringList videoCodecs READ videoCodecs)
     Q_PROPERTY(QStringList videoCodecPriority READ videoCodecPriority WRITE setVideoCodecPriority NOTIFY videoCodecPriorityChanged)
     Q_PROPERTY(QVariantMap videoCodecOptions READ videoCodecOptions WRITE setVideoCodecOptions NOTIFY videoCodecOptionsChanged)
+    Q_PROPERTY(bool useWallclockAsTimestamps READ useWallclockAsTimestamps WRITE setWallclockAsTimestamps NOTIFY useWallclockAsTimestampsChanged)
     Q_PROPERTY(QtAV::VideoCapture *videoCapture READ videoCapture CONSTANT)
     Q_PROPERTY(int audioTrack READ audioTrack WRITE setAudioTrack NOTIFY audioTrackChanged)
     Q_PROPERTY(QUrl externalAudio READ externalAudio WRITE setExternalAudio NOTIFY externalAudioChanged)
@@ -168,6 +169,9 @@ public:
     QVariantMap videoCodecOptions() const;
     void setVideoCodecOptions(const QVariantMap& value);
 
+    bool useWallclockAsTimestamps() const;
+    void setWallclockAsTimestamps(bool use_wallclock_as_timestamps);
+
     void setAudioChannels(int channels);
     int audioChannels() const;
     void setChannelLayout(ChannelLayout channel);
@@ -229,6 +233,7 @@ Q_SIGNALS:
     void bufferProgressChanged();
     void videoCodecPriorityChanged();
     void videoCodecOptionsChanged();
+    void useWallclockAsTimestampsChanged();
     void channelLayoutChanged();
     void timeoutChanged();
     void abortOnTimeoutChanged();
@@ -257,6 +262,7 @@ private Q_SLOTS:
 private:
     Q_DISABLE_COPY(QmlAVPlayer)
 
+    bool mUseWallclockAsTimestamps;
     bool m_complete;
     bool m_mute;
     bool mAutoPlay;

--- a/qml/plugins.qmltypes
+++ b/qml/plugins.qmltypes
@@ -203,6 +203,7 @@ Module {
         Property { name: "videoCodecPriority"; type: "QStringList" }
         Property { name: "videoCodecOptions"; type: "QVariantMap" }
         Property { name: "videoCapture"; type: "QtAV::VideoCapture"; isReadonly: true; isPointer: true }
+        Property { name: "useWallclockAsTimestamps"; type: "bool" }
         Property { name: "audioTrack"; type: "int" }
         Property { name: "externalAudio"; type: "QUrl" }
         Property { name: "internalAudioTracks"; type: "QVariantList"; isReadonly: true }


### PR DESCRIPTION
fixed #429

it has high latency because media source has no timestamp information(mjpeg format, lot of IP Camera and live streaming is using mjpeg), so use_wallclock_as_timestamps can solve this problem.

it was usually used with ffplay below:
$ ffplay -use_wallclock_as_timerstamp 1 test.mjpeg