### PR TITLE
Fixed resize bug in VideoRenderer if only height or width changes

### DIFF
--- a/src/output/video/VideoRenderer.cpp
+++ b/src/output/video/VideoRenderer.cpp
@@ -232,7 +232,7 @@ void VideoRenderer::resizeRenderer(const QSize &size)
 void VideoRenderer::resizeRenderer(int width, int height)
 {
     DPTR_D(VideoRenderer);
-    if (width == 0 || height == 0 || d.renderer_width == width || d.renderer_height == height)
+    if (width == 0 || height == 0 || (d.renderer_width == width && d.renderer_height == height))
         return;
     d.renderer_width = width;
     d.renderer_height = height;


### PR DESCRIPTION
If we try to resize player that has Renderer based on VideoRenderer, player won't be resized, if we change only height or width(i.e. if we resize using side of our window and not corners). Fix is obvious