### PR TITLE
fixed a crash when the audio decoder failed to create

### DIFF
--- a/src/AVPlayerPrivate.cpp
+++ b/src/AVPlayerPrivate.cpp
@@ -305,6 +305,11 @@ bool AVPlayer::Private::setupAudioThread(AVPlayer *player)
         adec = 0;
     }
     adec = AudioDecoder::create();
+    if (!adec)
+    {
+        qWarning("failed to create audio decoder");
+        return false;
+    }
     QObject::connect(adec, SIGNAL(error(QtAV::AVError)), player, SIGNAL(error(QtAV::AVError)));
     adec->setCodecContext(avctx);
     adec->setOptions(ac_opt);


### PR DESCRIPTION
I have QtAV configured only with ffmpeg (no need in playing audio).
When i load the file with audio stream, QtAV is crashing.