### PR TITLE
Remove Qt keywords(signals, slots) to make compatible with QT_NO_KEYWORDS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Makefile*
 .obj
 /bin*
 /lib*
+build
 Debug
 Release
 *.Debug
@@ -65,3 +66,6 @@ Release
 *.moc
 *qrc_res.cpp
 
+#cache
+*.pyc
+*.swp

--- a/src/QtAV/AVClock.h
+++ b/src/QtAV/AVClock.h
@@ -110,13 +110,13 @@ public:
      */
     bool syncEndOnce(int id);
 
-signals:
+Q_SIGNALS:
     void paused(bool);
     void paused(); //equals to paused(true)
     void resumed();//equals to paused(false)
     void started();
     void resetted();
-public slots:
+public Q_SLOTS:
     //these slots are not frequently used. so not inline
     /*start the external clock*/
     void start();

--- a/src/QtAV/AVDemuxer.h
+++ b/src/QtAV/AVDemuxer.h
@@ -187,7 +187,7 @@ public:
      */
     void setOptions(const QVariantHash &dict);
     QVariantHash options() const;
-signals:
+Q_SIGNALS:
     void unloaded();
     void userInterrupted(); //NO direct connection because it's emit before interrupted happens
     void loaded();

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -391,7 +391,7 @@ public:
     MediaEndAction mediaEndAction() const;
     void setMediaEndAction(MediaEndAction value);
 
-public slots:
+public Q_SLOTS:
     /*!
      * \brief load
      * Load the current media set by setFile(); Can be used to reload a media and call play() later. If already loaded, does nothing and return true.

--- a/src/QtAV/Filter.h
+++ b/src/QtAV/Filter.h
@@ -62,7 +62,7 @@ public:
     bool uninstall();
 public Q_SLOTS:
     void setEnabled(bool enabled = true);
-signals:
+Q_SIGNALS:
     void enabledChanged(bool);
 protected:
     /*

--- a/src/QtAV/OpenGLVideo.h
+++ b/src/QtAV/OpenGLVideo.h
@@ -102,7 +102,7 @@ Q_SIGNALS:
 protected:
     DPTR_DECLARE(OpenGLVideo)
 
-private slots:
+private Q_SLOTS:
     /* used by Qt5 whose QOpenGLContext is QObject and we can call this when context is about to destroy.
      * shader manager and material will be reset
      */

--- a/src/QtAV/Subtitle.h
+++ b/src/QtAV/Subtitle.h
@@ -179,7 +179,7 @@ public:
     void setFontsDir(const QString& value);
     bool isFontFileForced() const;
     void setFontFileForced(bool value);
-public slots:
+public Q_SLOTS:
     /*!
      * \brief start
      * start to process the whole subtitle content in a thread
@@ -187,7 +187,7 @@ public slots:
     void load();
     void loadAsync();
     void setTimestamp(qreal t);
-signals:
+Q_SIGNALS:
     // TODO: also add to AVPlayer?
     /// empty path if load from raw data
     void loaded(const QString& path = QString());

--- a/src/QtAV/SubtitleFilter.h
+++ b/src/QtAV/SubtitleFilter.h
@@ -83,15 +83,15 @@ public:
     QFont font() const;
     void setColor(const QColor& c);
     QColor color() const;
-public slots:
+public Q_SLOTS:
     // TODO: enable changed & autoload=> load
     void setAutoLoad(bool value);
-signals:
+Q_SIGNALS:
     void rectChanged();
     void fontChanged();
     void colorChanged();
     void autoLoadChanged(bool value);
-signals:
+Q_SIGNALS:
     void fileChanged();
     void canRenderChanged();
     void loaded(const QString& path);

--- a/src/QtAV/VideoCapture.h
+++ b/src/QtAV/VideoCapture.h
@@ -116,7 +116,7 @@ Q_SIGNALS:
     void qualityChanged();
     void captureNameChanged();
     void captureDirChanged();
-private slots:
+private Q_SLOTS:
     void handleAppQuit();
 private:
     void setVideoFrame(const VideoFrame& frame);


### PR DESCRIPTION
Also exclude *.pyc, *.swp and build/ directory. The former makes editing easier for vim users, and the latter is for convenience