### PR TITLE
Ignore hidden by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,17 @@
 CVS
 .#*
 
-.hg
-.hgignore
+# Hidden files are ignored by default with exceptions
+.*
+!/.gitignore
+!/.gitmodules
+!/.qmake.conf
+!/.travis.yml
 
 obj
 TestResults
 *.pbxuser
 *.perspectivev3
-.DS_Store
 
 *.old
 *.log
@@ -47,9 +50,6 @@ Makefile*
 *.ilk
 
 #dirs
-.moc
-.rcc
-.obj
 /bin*
 /lib*
 build

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ CVS
 !/.qmake.conf
 !/.travis.yml
 
+# .install files in debian/ are generated and ignored
+debian/*.install
+
 obj
 TestResults
 *.pbxuser
@@ -67,5 +70,4 @@ Release
 *qrc_res.cpp
 
 #cache
-*.pyc
 *.swp


### PR DESCRIPTION
On *nix, file names that start with a dot are hidden.
I would like to propose this change since it makes vim editing easier.

I also added a rule to ignore .install files in debian/ since .install files are generated automatically in debian/ when the command `make install` is executed.