### PR TITLE
set the Player's style to Fusion for OS X; #738

### DIFF
--- a/examples/player/MainWindow.cpp
+++ b/examples/player/MainWindow.cpp
@@ -48,6 +48,8 @@
 #include <QToolTip>
 #include <QKeyEvent>
 #include <QWheelEvent>
+#include <QStyleFactory>
+
 #include "ClickableMenu.h"
 #include "Slider.h"
 #include "StatisticsView.h"
@@ -110,6 +112,10 @@ MainWindow::MainWindow(QWidget *parent) :
   , m_preview(0)
   , m_shader(NULL)
 {
+    #if defined(Q_OS_MACX) && QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        QApplication::setStyle(QStyleFactory::create("Fusion"));
+    #endif
+
     setWindowIcon(QIcon(QString::fromLatin1(":/QtAV.svg")));
     mpOSD = new OSDFilter(this);
     mpSubtitle = new SubtitleFilter(this);


### PR DESCRIPTION
The cross-platform Qt5 style "Fusion" timeline indicator does not suffer from issue #738
which implies this is an upstream issue.

I did find a couple bug reports that seem similar...
and one notes it's OS X / Retina specific,
which is what I'm using.
https://bugreports.qt.io/browse/QTBUG-48084