### PR TITLE
Add muxerAudioTracks to AVPlayer and fix issue with signal/slot connections in EncodeFilter.cpp

### DIFF
--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -225,7 +225,6 @@ public:
     void setAudioTrack(int value);
     QVariantList internalAudioTracks() const;
     /*!
-    /*!
      * \brief videoTrack
      * The video stream number in current media.
      * Value can be: 0, 1, 2.... 0 means the 1st video stream in current media

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -1063,6 +1063,18 @@ int AVPlayer::currentAudioStream() const
     return d->demuxer.audioStreams().indexOf(d->demuxer.audioStream());
 }
 
+// added by calin
+QList<int> AVPlayer::muxerAudioTracks() const
+{
+    return d->demuxer.audioStreams();
+}
+
+// added by calin
+QList<int> AVPlayer::muxerVideoTracks() const
+{
+    return d->demuxer.videoStreams();
+}
+
 int AVPlayer::currentVideoStream() const
 {
     return d->demuxer.videoStreams().indexOf(d->demuxer.videoStream());

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -206,6 +206,20 @@ public:
     const QVariantList& externalAudioTracks() const;
     const QVariantList& internalAudioTracks() const;
     const QVariantList& internalVideoTracks() const;
+
+    /*!
+     * \brief muxerVideoTracks
+     * get FFmpeg stream id's (actual track number) from the muxer for the set of video tracks for the movie file -- useful if you need to interface with external libraries
+     * \return a list of track id's for the video tracks (if any) in the source file, eg { 0, 1, 3, 6 } etc
+     */
+    QList<int> muxerVideoTracks() const;
+    /*!
+     * \brief muxerAudioTracks
+     * get FFmpeg stream id's (actual track number) from the muxer for the set of audio tracks for the movie file -- useful if you need to interface with external libraries
+     * \return a list of track id's for the audio tracks (if any) in the source file, eg { 2, 4, 5 } etc
+     */
+    QList<int> muxerAudioTracks() const;
+
     /*!
      * \brief setAudioStream
      * set an external audio file and stream number as audio track. It will be reset if setFile()/setIODevice()/setInput() is called

--- a/src/QtAV/EncodeFilter.h
+++ b/src/QtAV/EncodeFilter.h
@@ -82,7 +82,7 @@ Q_SIGNALS:
     void frameEncoded(const QtAV::Packet& packet);
     void startTimeChanged(qint64 value);
     // internal use only
-    void requestToEncode(const AudioFrame& frame);
+    void requestToEncode(const QtAV::AudioFrame& frame);
 protected Q_SLOTS:
     void encode(const QtAV::AudioFrame& frame = AudioFrame());
 protected:

--- a/src/filter/EncodeFilter.cpp
+++ b/src/filter/EncodeFilter.cpp
@@ -52,7 +52,11 @@ public:
 AudioEncodeFilter::AudioEncodeFilter(QObject *parent)
     : AudioFilter(*new AudioEncodeFilterPrivate(), parent)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     connect(this, SIGNAL(requestToEncode(QtAV::AudioFrame)), this, SLOT(encode(QtAV::AudioFrame)));
+#else
+    connect(this, &AudioEncodeFilter::requestToEncode, this, &AudioEncodeFilter::encode);
+#endif
     connect(this, SIGNAL(finished()), &d_func().enc_thread, SLOT(quit()));
 }
 
@@ -204,7 +208,11 @@ public:
 VideoEncodeFilter::VideoEncodeFilter(QObject *parent)
     : VideoFilter(*new VideoEncodeFilterPrivate(), parent)
 {
-    connect(this, SIGNAL(requestToEncode(QtAV::VideoFrame)), this, SLOT(encode(QtAV::VideoFrame)));
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+      connect(this, SIGNAL(requestToEncode(QtAV::VideoFrame)), this, SLOT(encode(QtAV::VideoFrame)));
+#else
+    connect(this, &VideoEncodeFilter::requestToEncode, this, &VideoEncodeFilter::encode);
+#endif
     connect(this, SIGNAL(finished()), &d_func().enc_thread, SLOT(quit()));
 }
 


### PR DESCRIPTION
I was getting errors when using AVTranscoder about bad signal/slot connection in Qt5 for the AudioEncodeFilter. I tried various things and it seemed to be related to qRegisterTypes or whatever it's called for registering custom types for signal/slot parameter marshalling.

I decided on Qt5 is it more elegant anyway to connect via method (to avoid this strangeness).

So I added some macros for Qt5 to fix this issue.

Also renamed the parameter to encodeFrame() in AudioEncodeFilter to hopefully work with Qt4 (before I was getting bad slot warning at runtime because the slot was declared accepting AudioFrame but the full typename is QtAV::AudioFrame).  I'm never clear on how scoping works in Qt SIGNAL/SLOTS, actually.  I think the meta type system does deal with name lookups too well since it's macro-based.

So.. in Qt5 -- let's just do a compile-time check by using the new 'functor' based signal/slot connections.

Also added querying muxer track id's to AVPlayer -- might be useful if using external libs and want to refer to audio tracks by absolute id, etc.