### PR TITLE
fixed thread handling, saved painter state

### DIFF
--- a/widgets/GraphicsItemRenderer.cpp
+++ b/widgets/GraphicsItemRenderer.cpp
@@ -303,7 +303,7 @@ bool GraphicsItemRenderer::onSetSaturation(qreal s)
 bool GraphicsItemRenderer::event(QEvent *event)
 {
     if (e->type() == QEvent::User) {
-		scene()->update(sceneBoundingRect());äääää
+		scene()->update(sceneBoundingRect());
     }
 	else {
         setFocus(); //WHY: Force focus

--- a/widgets/QtAVWidgets/GraphicsItemRenderer.h
+++ b/widgets/QtAVWidgets/GraphicsItemRenderer.h
@@ -104,6 +104,7 @@ protected:
 #if CONFIG_GRAPHICSWIDGET
     bool event(QEvent *event) Q_DECL_OVERRIDE;
 #else
+    bool event(QEvent *event) Q_DECL_OVERRIDE;
     //bool sceneEvent(QEvent *event) Q_DECL_OVERRIDE;
 #endif //CONFIG_GRAPHICSWIDGET
 


### PR DESCRIPTION
Dear Wang Bin,
I patched GraphicsItemRenderer, so it doesn't crash anymore and doesn't violate the painter state in drawFrame.
I'm not sure begin/endNativePainting are necessary, but when I looked last time the invoked method uses native OpenGL calls.
The scene update is done in event, the same way you do it in QuickFBORenderer.

cheers,
Andor