### PR TITLE
Fix issues with AudioEncodeFilter not receiving frames due to bad signal/slot connection in Qt5 and added "muxerAudioTracks" and "muxerVideoTracks" to AVPlayer

### DIFF
--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -225,7 +225,6 @@ public:
     void setAudioTrack(int value);
     QVariantList internalAudioTracks() const;
     /*!
-    /*!
      * \brief videoTrack
      * The video stream number in current media.
      * Value can be: 0, 1, 2.... 0 means the 1st video stream in current media

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -1088,6 +1088,18 @@ int AVPlayer::subtitleStreamCount() const
     return d->demuxer.subtitleStreams().size();
 }
 
+// added by calin
+QList<int> AVPlayer::muxerAudioTracks() const
+{
+    return d->demuxer.audioStreams();
+}
+
+// added by calin
+QList<int> AVPlayer::muxerVideoTracks() const
+{
+    return d->demuxer.videoStreams();
+}
+
 AVPlayer::State AVPlayer::state() const
 {
     return d->state;

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -206,6 +206,20 @@ public:
     const QVariantList& externalAudioTracks() const;
     const QVariantList& internalAudioTracks() const;
     const QVariantList& internalVideoTracks() const;
+
+    /*!
+     * \brief muxerVideoTracks
+     * get FFmpeg stream id's (actual track number) from the muxer for the set of video tracks for the movie file -- useful if you need to interface with external libraries
+     * \return a list of track id's for the video tracks (if any) in the source file, eg { 0, 1, 3, 6 } etc
+     */
+    QList<int> muxerVideoTracks() const;
+    /*!
+     * \brief muxerAudioTracks
+     * get FFmpeg stream id's (actual track number) from the muxer for the set of audio tracks for the movie file -- useful if you need to interface with external libraries
+     * \return a list of track id's for the audio tracks (if any) in the source file, eg { 2, 4, 5 } etc
+     */
+    QList<int> muxerAudioTracks() const;
+
     /*!
      * \brief setAudioStream
      * set an external audio file and stream number as audio track. It will be reset if setFile()/setIODevice()/setInput() is called

--- a/src/QtAV/EncodeFilter.h
+++ b/src/QtAV/EncodeFilter.h
@@ -82,7 +82,7 @@ Q_SIGNALS:
     void frameEncoded(const QtAV::Packet& packet);
     void startTimeChanged(qint64 value);
     // internal use only
-    void requestToEncode(const AudioFrame& frame);
+    void requestToEncode(const QtAV::AudioFrame& frame);
 protected Q_SLOTS:
     void encode(const QtAV::AudioFrame& frame = AudioFrame());
 protected:

--- a/src/filter/EncodeFilter.cpp
+++ b/src/filter/EncodeFilter.cpp
@@ -52,7 +52,11 @@ public:
 AudioEncodeFilter::AudioEncodeFilter(QObject *parent)
     : AudioFilter(*new AudioEncodeFilterPrivate(), parent)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     connect(this, SIGNAL(requestToEncode(QtAV::AudioFrame)), this, SLOT(encode(QtAV::AudioFrame)));
+#else
+    connect(this, &AudioEncodeFilter::requestToEncode, this, &AudioEncodeFilter::encode);
+#endif
     connect(this, SIGNAL(finished()), &d_func().enc_thread, SLOT(quit()));
 }
 
@@ -204,7 +208,11 @@ public:
 VideoEncodeFilter::VideoEncodeFilter(QObject *parent)
     : VideoFilter(*new VideoEncodeFilterPrivate(), parent)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     connect(this, SIGNAL(requestToEncode(QtAV::VideoFrame)), this, SLOT(encode(QtAV::VideoFrame)));
+#else
+    connect(this, &VideoEncodeFilter::requestToEncode, this, &VideoEncodeFilter::encode);
+#endif
     connect(this, SIGNAL(finished()), &d_func().enc_thread, SLOT(quit()));
 }
 


### PR DESCRIPTION
Hi,

This patch has 2 separate things it adds:

1. There was an issue in AVTranscoder not working right for audio on Qt5.  The issue was with AudioEncodeFilter and I was getting Qt complaining it could not find the SIGNAL(requestToEncode(QtAV::AudioFrame)) -- because of the way it was declared.  I decided to go ahead and make that connection compile-time-checked (using Qt5's new functor-style connections) rather than runtime checked, because of my own paranoia.  

2. I added querying the player for "muxerAudioTracks" and "muxerVideoTracks" which returns the actual indexes in the muxed movie file for video and audio tracks.  This is useful if you need to also communicate with outside libs that only receive parameters in terms of muxed file track index.

Thanks!

