### PR TITLE
Mac OSX: Fix to stop using deprecated API to turn off ScreenSaver in ScreenSaver.cpp

### DIFF
--- a/examples/common/ScreenSaver.h
+++ b/examples/common/ScreenSaver.h
@@ -33,6 +33,7 @@ private:
     int allowExposures;
 #endif //Q_OS_LINUX
     int ssTimerId; //for mac
+    quint32 osxIOPMAssertionId; // for mac OSX >= 10.8
 };
 
 #endif // SCREENSAVER_H


### PR DESCRIPTION
This warning was a little bit disconcerting when compiling (I like warning-free compiles -- I'm a bit of  a nazi).

Also -- Apple is pretty nasty with their deprecated APIs (sometimes taking them out altogether!).  They also don't accept deprecated calls in App Store.   So I figured I'd help out by adding the "new" OSX 10.8+ API for turning off the screen-saver.

Old style API calls are there if compiling on SDK for OSX < 10.8.. so no harm is done.
