### PR TITLE
Added muxer stream_index key to internalAudioTracks, internalVideoTracks, externalAudioTracks in AVPlayer and misc other fixups

### DIFF
--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -225,7 +225,6 @@ public:
     void setAudioTrack(int value);
     QVariantList internalAudioTracks() const;
     /*!
-    /*!
      * \brief videoTrack
      * The video stream number in current media.
      * Value can be: 0, 1, 2.... 0 means the 1st video stream in current media

--- a/src/AVPlayerPrivate.cpp
+++ b/src/AVPlayerPrivate.cpp
@@ -459,6 +459,8 @@ QVariantList AVPlayer::Private::getTracksInfo(AVDemuxer *demuxer, AVDemuxer::Str
         QVariantMap t;
         t[QStringLiteral("id")] = info.size();
         t[QStringLiteral("file")] = demuxer->fileName();
+        t[QStringLiteral("stream_index")] = QVariant(s);
+
         AVStream *stream = demuxer->formatContext()->streams[s];
         AVCodecContext *ctx = stream->codec;
         if (ctx) {

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -199,12 +199,30 @@ public:
     /*!
      * \brief externalAudioTracks
      * A list of QVariantMap. Using QVariantMap and QVariantList is mainly for QML support.
-     * [ {id: 0, file: abc.dts, language: eng, title: xyz}, ...]
+     * [ {id: 0, stream_index: 2, file: abc.dts, language: eng, title: xyz}, ...]
      * id: used for setAudioStream(id)
+     * stream_index: the actual muxer stream index -- not used by API to this class but possibly
+     *               useful for interop with external libs that require absolute stream_index
      * \sa externalAudioTracksChanged
      */
     const QVariantList& externalAudioTracks() const;
+    /*!
+     * \brief internalAudioTracks
+     * A list of QVariantMap. Using QVariantMap and QVariantList is mainly for QML support.
+     * [ {id: 0, stream_index: 2, file: abc.dts, language: eng, title: xyz}, ...]
+     * id: used for setAudioStream(id)
+     * stream_index: the actual muxer stream index -- not used by API to this class but possibly
+     *               useful for interop with external libs that require absolute stream_index
+     */
     const QVariantList& internalAudioTracks() const;
+    /*!
+     * \brief internalVideoTracks
+     * A list of QVariantMap. Using QVariantMap and QVariantList is mainly for QML support.
+     * [ {id: 0, stream_index: 2, file: abc.dts, language: eng, title: xyz}, ...]
+     * id: used for setAudioStream(id)
+     * stream_index: the actual muxer stream index -- not used by API to this class but possibly
+     *               useful for interop with external libs that require absolute stream_index
+     */
     const QVariantList& internalVideoTracks() const;
     /*!
      * \brief setAudioStream

--- a/src/QtAV/EncodeFilter.h
+++ b/src/QtAV/EncodeFilter.h
@@ -82,7 +82,7 @@ Q_SIGNALS:
     void frameEncoded(const QtAV::Packet& packet);
     void startTimeChanged(qint64 value);
     // internal use only
-    void requestToEncode(const AudioFrame& frame);
+    void requestToEncode(const QtAV::AudioFrame& frame);
 protected Q_SLOTS:
     void encode(const QtAV::AudioFrame& frame = AudioFrame());
 protected:

--- a/src/filter/EncodeFilter.cpp
+++ b/src/filter/EncodeFilter.cpp
@@ -52,7 +52,11 @@ public:
 AudioEncodeFilter::AudioEncodeFilter(QObject *parent)
     : AudioFilter(*new AudioEncodeFilterPrivate(), parent)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     connect(this, SIGNAL(requestToEncode(QtAV::AudioFrame)), this, SLOT(encode(QtAV::AudioFrame)));
+#else
+    connect(this, &AudioEncodeFilter::requestToEncode, this, &AudioEncodeFilter::encode);
+#endif
     connect(this, SIGNAL(finished()), &d_func().enc_thread, SLOT(quit()));
 }
 
@@ -204,7 +208,11 @@ public:
 VideoEncodeFilter::VideoEncodeFilter(QObject *parent)
     : VideoFilter(*new VideoEncodeFilterPrivate(), parent)
 {
-    connect(this, SIGNAL(requestToEncode(QtAV::VideoFrame)), this, SLOT(encode(QtAV::VideoFrame)));
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+      connect(this, SIGNAL(requestToEncode(QtAV::VideoFrame)), this, SLOT(encode(QtAV::VideoFrame)));
+#else
+    connect(this, &VideoEncodeFilter::requestToEncode, this, &VideoEncodeFilter::encode);
+#endif
     connect(this, SIGNAL(finished()), &d_func().enc_thread, SLOT(quit()));
 }
 


### PR DESCRIPTION
This PR does 3 things:

1. Adds a new key to the QVariantMap info dictionary returned from AVPlayer::internalAudioTracks(), AVPlayer::internalVideoTracks() and AVPlayer::externalAudioTracks.  The stream_index is basically the index of the stream in the muxed file.  May be useful for code that interoperates with external libs.

2. Fixed a runtime error on Qt5 whereby could not connect AudioEncodeFilter requestEncode to the encode() method because the method name took parameter 'AudioFrame' rather than QtAV::AudioFrame.  I decided to go ahead and do Qt5-style method connections for these two as they are slightly cleaner (at compiler-time).

3. Fixed a warning about /* within a comment.
