### PR TITLE
修复Player出现视频预览小窗后其解码所需的额外内存不会在其关闭后释放的问题

### DIFF
--- a/examples/player/MainWindow.cpp
+++ b/examples/player/MainWindow.cpp
@@ -1325,7 +1325,7 @@ void MainWindow::onTimeSliderHover(int pos, int value)
     m_preview->preview();
     const int w = Config::instance().previewWidth();
     const int h = Config::instance().previewHeight();
-    m_preview->setWindowFlags(m_preview->windowFlags() |Qt::FramelessWindowHint|Qt::WindowStaysOnTopHint);
+    m_preview->setWindowFlags(Qt::Tool |Qt::FramelessWindowHint|Qt::WindowStaysOnTopHint);
     m_preview->resize(w, h);
     m_preview->move(gpos - QPoint(w/2, h));
     m_preview->show();

--- a/examples/player/MainWindow.cpp
+++ b/examples/player/MainWindow.cpp
@@ -1344,7 +1344,7 @@ void MainWindow::onTimeSliderLeave()
         m_preview->close();
     }
     delete m_preview;
-    m_preview = nullptr;
+    m_preview = NULL;
 }
 
 void MainWindow::handleError(const AVError &e)

--- a/examples/player/MainWindow.cpp
+++ b/examples/player/MainWindow.cpp
@@ -1333,8 +1333,18 @@ void MainWindow::onTimeSliderHover(int pos, int value)
 
 void MainWindow::onTimeSliderLeave()
 {
-    if (m_preview && m_preview->isVisible())
-        m_preview->hide();
+    /*if (m_preview && m_preview->isVisible())
+        m_preview->hide();*/
+    if (!m_preview)
+    {
+        return;
+    }
+    if (m_preview->isVisible())
+    {
+        m_preview->close();
+    }
+    delete m_preview;
+    m_preview = nullptr;
 }
 
 void MainWindow::handleError(const AVError &e)


### PR DESCRIPTION
鼠标离开TimeSlider后即删除m_preview窗口，其解码过程即刻停止，内存占用即可下降