### PR TITLE
prevent buffer to be emptied when bufferValue is greater than 1

### DIFF
--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -93,6 +93,16 @@ AVPlayer::AVPlayer(QObject *parent) :
     connect(d->read_thread, SIGNAL(seekFinished(qint64)), this, SLOT(onSeekFinished(qint64)), Qt::DirectConnection);
     connect(d->read_thread, SIGNAL(internalSubtitlePacketRead(int, QtAV::Packet)), this, SIGNAL(internalSubtitlePacketRead(int, QtAV::Packet)), Qt::DirectConnection);
     d->vcapture = new VideoCapture(this);
+
+    connect(this,&AVPlayer::bufferProgressChanged,this,[this](qreal value){
+        if(d->buffer_value>1)
+        {
+            if(value<=0.1)
+                d->clock->pause(true);
+            else if(d->clock->isPaused())
+                d->clock->pause(false);
+        }
+    });
 }
 
 AVPlayer::~AVPlayer()


### PR DESCRIPTION
Suppose you are playing video from stream of an IP camera which does not have sound and the clock type is external. Also the stream has a low bit rate. After the buffer is full, the player starts and `buffered()` gradually decreases until it reaches 0.  That's when playing stream stops and it waits to buffer again. When buffered it plays video frames very fast and starts buffering again. This is continued in a loop resulting a bad preview of the video stream. 
This workaround checks the `bufferProgress` and if the buffer is going to be empty, the master clock is paused for a moment until a little more data is buffered. This solves the problem.