### PR TITLE
add adaptive buffer mode

### DIFF
--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -80,6 +80,7 @@ class QmlAVPlayer : public QObject, public QQmlParserStatus
     Q_PROPERTY(int audioTrack READ audioTrack WRITE setAudioTrack NOTIFY audioTrackChanged)
     Q_PROPERTY(int videoTrack READ videoTrack WRITE setVideoTrack NOTIFY videoTrackChanged)
     Q_PROPERTY(int bufferSize READ bufferSize WRITE setBufferSize NOTIFY bufferSizeChanged)
+    Q_PROPERTY(bool adaptiveBuffer READ adaptiveBuffer WRITE setAdaptiveBuffer NOTIFY adaptiveBufferChanged)
     Q_PROPERTY(QUrl externalAudio READ externalAudio WRITE setExternalAudio NOTIFY externalAudioChanged)
     Q_PROPERTY(QVariantList internalAudioTracks READ internalAudioTracks NOTIFY internalAudioTracksChanged)
     Q_PROPERTY(QVariantList internalVideoTracks READ internalVideoTracks NOTIFY internalVideoTracksChanged)
@@ -235,6 +236,9 @@ public:
 
     int bufferSize() const;
     void setBufferSize(int value);
+
+    int adaptiveBuffer() const;
+    void setAdaptiveBuffer(bool value);
     /*!
      * \brief externalAudio
      * If externalAudio url is valid, player will use audioTrack of external audio as audio source.
@@ -306,6 +310,7 @@ Q_SIGNALS:
     void internalSubtitleTrackChanged();
     void internalSubtitleTracksChanged();
     void bufferSizeChanged();
+    void adaptiveBufferChanged();
 
     void errorChanged();
     void error(Error error, const QString &errorString);

--- a/qml/QmlAVPlayer.cpp
+++ b/qml/QmlAVPlayer.cpp
@@ -425,6 +425,21 @@ void QmlAVPlayer::setBufferSize(int value)
     }
 }
 
+int QmlAVPlayer::adaptiveBuffer() const
+{
+    return mpPlayer->adaptiveBuffer();
+}
+
+void QmlAVPlayer::setAdaptiveBuffer(bool value)
+{
+    if (mpPlayer->adaptiveBuffer() == value)
+        return;
+    if (mpPlayer) {
+        mpPlayer->setAdaptiveBuffer(value);
+        Q_EMIT adaptiveBufferChanged();
+    }
+}
+
 QUrl QmlAVPlayer::externalAudio() const
 {
     return m_audio;

--- a/qml/plugins.qmltypes
+++ b/qml/plugins.qmltypes
@@ -230,6 +230,7 @@ Module {
         Property { name: "videoCapture"; type: "QtAV::VideoCapture"; isReadonly: true; isPointer: true }
         Property { name: "audioTrack"; type: "int" }
         Property { name: "bufferSize"; type: "int" }
+        Property { name: "adaptiveBuffer"; type: "bool" }
         Property { name: "externalAudio"; type: "QUrl" }
         Property { name: "internalAudioTracks"; type: "QVariantList"; isReadonly: true }
         Property { name: "externalAudioTracks"; type: "QVariantList"; isReadonly: true }

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -466,6 +466,20 @@ void AVPlayer::setMediaEndAction(MediaEndAction value)
     d->read_thread->setMediaEndAction(value);
 }
 
+bool AVPlayer::adaptiveBuffer() const
+{
+    return d->adaptive_buffer;
+}
+
+void AVPlayer::setAdaptiveBuffer(bool value)
+{
+    if (d->adaptive_buffer == value)
+        return;
+    d->adaptive_buffer = value;
+    d->applyAdaptiveBuffer(this);
+    Q_EMIT adaptiveBufferChanged(value);
+}
+
 MediaEndAction AVPlayer::mediaEndAction() const
 {
     return d->end_action;
@@ -1383,6 +1397,18 @@ void AVPlayer::tryClearVideoRenderers()
     if (!(mediaEndAction() & MediaEndAction_KeepDisplay)) {
         d->vthread->clearRenderers();
     }
+}
+
+void AVPlayer::updateAdaptiveBuffer()
+{
+    d->bufferHistory.push_back(buffered());
+    if(d->bufferHistory.size()>50)
+        d->bufferHistory.pop_front();
+
+    qint64 bufferMax = *std::max_element(d->bufferHistory.begin(), d->bufferHistory.end());
+    qint64 bufferVal = qMin(qMax(bufferMax, (qint64)1), (qint64)128);
+
+    setBufferValue(bufferVal);
 }
 
 void AVPlayer::stop()

--- a/src/AVPlayerPrivate.cpp
+++ b/src/AVPlayerPrivate.cpp
@@ -111,6 +111,7 @@ AVPlayer::Private::Private()
     , status(NoMedia)
     , state(AVPlayer::StoppedState)
     , end_action(MediaEndAction_Default)
+    ,adaptive_buffer(false)
 {
     demuxer.setInterruptTimeout(interrupt_timeout);
     /*
@@ -646,6 +647,19 @@ void AVPlayer::Private::updateBufferValue()
         updateBufferValue(athread->packetQueue());
     if (vthread)
         updateBufferValue(vthread->packetQueue());
+}
+
+void AVPlayer::Private::applyAdaptiveBuffer(AVPlayer *player)
+{
+    if(adaptive_buffer)
+    {
+        bufferHistory.clear();
+        adaptiveBuffer_timer.setInterval(100);
+        connect(&adaptiveBuffer_timer,SIGNAL(timeout()),player,SLOT(updateAdaptiveBuffer()));
+        connect(player,SIGNAL(started()),&adaptiveBuffer_timer,SLOT(start()));
+    }
+    else
+        adaptiveBuffer_timer.disconnect();
 }
 
 } //namespace QtAV

--- a/src/AVPlayerPrivate.h
+++ b/src/AVPlayerPrivate.h
@@ -28,6 +28,8 @@
 #include "VideoThread.h"
 #include "AVDemuxThread.h"
 #include "utils/Logger.h"
+#include <QTimer>
+#include <queue>
 
 namespace QtAV {
 
@@ -100,6 +102,8 @@ public:
         }
     }
 
+    void applyAdaptiveBuffer(AVPlayer *player);
+
     bool auto_load;
     bool async_load;
     // can be QString, QIODevice*
@@ -155,6 +159,10 @@ public:
     AVPlayer::State state;
     MediaEndAction end_action;
     QMutex load_mutex;
+
+    bool adaptive_buffer;
+    QTimer adaptiveBuffer_timer;
+    std::deque<qint64> bufferHistory;
 };
 
 } //namespace QtAV

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -82,6 +82,7 @@ class Q_AV_EXPORT AVPlayer : public QObject
     Q_PROPERTY(State state READ state WRITE setState NOTIFY stateChanged)
     Q_PROPERTY(QtAV::MediaStatus mediaStatus READ mediaStatus NOTIFY mediaStatusChanged)
     Q_PROPERTY(QtAV::MediaEndAction mediaEndAction READ mediaEndAction WRITE setMediaEndAction NOTIFY mediaEndActionChanged)
+    Q_PROPERTY(bool adaptiveBuffer READ adaptiveBuffer WRITE setAdaptiveBuffer NOTIFY adaptiveBufferChanged)
     Q_ENUMS(State)
 public:
     /*!
@@ -409,6 +410,12 @@ public:
      */
     MediaEndAction mediaEndAction() const;
     void setMediaEndAction(MediaEndAction value);
+    /*!
+     * \brief adaptiveBuffer
+     * adaptive buffer size based on bit rate.
+     */
+    bool adaptiveBuffer() const;
+    void setAdaptiveBuffer(bool value);
 
 public Q_SLOTS:
     /*!
@@ -545,6 +552,7 @@ Q_SIGNALS:
     void loaded(); // == mediaStatusChanged(QtAV::LoadedMedia)
     void mediaStatusChanged(QtAV::MediaStatus status); //explictly use QtAV::MediaStatus
     void mediaEndActionChanged(QtAV::MediaEndAction action);
+    void adaptiveBufferChanged(bool);
     /*!
      * \brief durationChanged emit when media is loaded/unloaded
      */
@@ -611,6 +619,7 @@ private Q_SLOTS:
     void updateMediaStatus(QtAV::MediaStatus status);
     void onSeekFinished(qint64 value);
     void tryClearVideoRenderers();
+    void updateAdaptiveBuffer();
 protected:
     // TODO: set position check timer interval
     virtual void timerEvent(QTimerEvent *);


### PR DESCRIPTION
If the proper `bufferSize` is not set for a player when playing video streams, the output would not be desirable for streams with different bit rates or a stream with varying bit rate. For example if you don't set buffer size and play a video stream with a relatively high bit rate, it would result in a bad render. that's because no sufficient video packets are buffered when rendering.
It seems to be good if `bufferSize` is set in an adaptive way. This pull request adds the `adaptiveBuffer` feature.