### PR TITLE
Mac/iOS: Include default brew-installed FFMPEG directory path

### DIFF
--- a/config.tests/paths.pri
+++ b/config.tests/paths.pri
@@ -4,5 +4,11 @@ INCLUDEPATH += $$[QT_INSTALL_HEADERS]
 LIBS += -L$$[QT_INSTALL_LIBS]
 CONFIG -= qt app_bundle lib_bundle
 CONFIG += console
+
+mac {
+    INCLUDEPATH += /usr/local/include/
+    LIBS += -L/usr/local/lib
+}
+
 *msvc*: INCLUDEPATH *= $$PWD/../src/compat/msvc
 !config_dx: INCLUDEPATH *= $$PWD/../contrib/dxsdk

--- a/src/libQtAV.pro
+++ b/src/libQtAV.pro
@@ -17,6 +17,11 @@ CONFIG *= qtav-buildlib
 static: CONFIG *= static_ffmpeg
 INCLUDEPATH += $$[QT_INSTALL_HEADERS] # TODO: ffmpeg dir
 
+mac {
+    INCLUDEPATH += /usr/local/include/
+    LIBS += -L/usr/local/lib
+}
+
 #mac: simd.prf will load qt_build_config and the result is soname will prefixed with QT_INSTALL_LIBS and link flag will append soname after QMAKE_LFLAGS_SONAME
 config_libcedarv: CONFIG *= neon config_simd #need by qt4 addSimdCompiler(). neon or config_neon is required because tests/arch can not detect neon
 ## sse2 sse4_1 may be defined in Qt5 qmodule.pri but is not included. Qt4 defines sse and sse2


### PR DESCRIPTION
This reduces build-environment complexity by including default paths for FFPEG as installed by `brew`. Tested to work both for macOS and iOS builds.