### PR TITLE
Set the avg_frame_rate for newly created AVStream (Fixes #955)

### DIFF
--- a/src/AVMuxer.cpp
+++ b/src/AVMuxer.cpp
@@ -116,6 +116,8 @@ AVStream *AVMuxer::Private::addStream(AVFormatContext* ctx, const QString &codec
     // set by avformat if unset
     s->id = ctx->nb_streams - 1;
     s->time_base = kTB;
+    // Set avg_frame_rate based on encoder frame_rate
+    s->avg_frame_rate = av_d2q(1.0/venc->frameRate(), venc->frameRate()*1001.0+2);
     AVCodecContext *c = s->codec;
     c->codec_id = codec->id;
     // Using codec->time_base is deprecated, but needed for older lavf.


### PR DESCRIPTION
Set avg_frame_rate of newly created AVStream in AVMuxer to frame_rate of the associated VideoEncoder

Fixes the calculation of the DefaultDuration field for MKV/WEBM files. Otherwise the DefaultDuration would have been equal to the time_base (1000ms / fps) which leads to playback failures in Google Chrome.