### PR TITLE
Fix possible null pointer access introduced in PR #959

### DIFF
--- a/src/AVMuxer.cpp
+++ b/src/AVMuxer.cpp
@@ -116,8 +116,10 @@ AVStream *AVMuxer::Private::addStream(AVFormatContext* ctx, const QString &codec
     // set by avformat if unset
     s->id = ctx->nb_streams - 1;
     s->time_base = kTB;
-    // Set avg_frame_rate based on encoder frame_rate
-    s->avg_frame_rate = av_d2q(1.0/venc->frameRate(), venc->frameRate()*1001.0+2);
+    if (venc) {
+        // Set avg_frame_rate based on video encoder frame_rate
+        s->avg_frame_rate = av_d2q(1.0/venc->frameRate(), venc->frameRate()*1001.0+2);   
+    }
     AVCodecContext *c = s->codec;
     c->codec_id = codec->id;
     // Using codec->time_base is deprecated, but needed for older lavf.


### PR DESCRIPTION
Sorry for the double PR but this fixes a possible null pointer access that I introduced with PR #959

When having only an audio stream to encode, there is no venc that can be asked for its frame rate.