### PR TITLE
fix the bug that multiple players are rendered when changing source o…

### DIFF
--- a/qml/QuickFBORenderer.cpp
+++ b/qml/QuickFBORenderer.cpp
@@ -151,6 +151,17 @@ void QuickFBORenderer::setSource(QObject *source)
     DPTR_D(QuickFBORenderer);
     if (d.source == source)
         return;
+
+    AVPlayer* p0 = 0;
+    p0 = qobject_cast<AVPlayer*>(d.source);
+    if (!p0) {
+        QmlAVPlayer* qp0 = qobject_cast<QmlAVPlayer*>(d.source);
+        if (qp0)
+            p0 = qp0->player();
+    }
+    if(p0)
+        p0->removeVideoRenderer(this);
+
     d.source = source;
     Q_EMIT sourceChanged();
     if (!source)


### PR DESCRIPTION
If you change `source` property of a `VideoOutput2` to a different `AVPlayer `in QML, the video output displays the frames from both the present and the previous players in an interleaved manner.
This commit removes video renderer from the previous player and thus fixes this problem.