### PR TITLE
Copy over initial_padding, extradata_size and extradata from avctx to newly created audio stream

### DIFF
--- a/src/AVMuxer.cpp
+++ b/src/AVMuxer.cpp
@@ -159,6 +159,14 @@ bool AVMuxer::Private::prepareStreams()
             c->channel_layout = aenc->audioFormat().channelLayoutFFmpeg();
             c->channels = aenc->audioFormat().channels();
             c->bits_per_raw_sample = aenc->audioFormat().bytesPerSample()*8; // need??
+
+            AVCodecContext *avctx = (AVCodecContext *) aenc->codecContext();
+            c->initial_padding = avctx->initial_padding;
+            if (avctx->extradata_size) {
+                c->extradata = avctx->extradata;
+                c->extradata_size = avctx->extradata_size;
+            }
+
             audio_streams.push_back(s->id);
         }
     }

--- a/src/AVMuxer.cpp
+++ b/src/AVMuxer.cpp
@@ -161,7 +161,11 @@ bool AVMuxer::Private::prepareStreams()
             c->bits_per_raw_sample = aenc->audioFormat().bytesPerSample()*8; // need??
 
             AVCodecContext *avctx = (AVCodecContext *) aenc->codecContext();
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56,5,100)
             c->initial_padding = avctx->initial_padding;
+#else
+            c->delay = avctx->delay;
+#endif
             if (avctx->extradata_size) {
                 c->extradata = avctx->extradata;
                 c->extradata_size = avctx->extradata_size;


### PR DESCRIPTION
This is needed for audio codecs that for example use the CodecPrivate
element in the WEBM container. The CodecPrivate field can contain
headers or other additional data. The audio codec OPUS cannot be
decoded without this element. Some audio codecs also define an
initial_padding which can be written as CodecDelay into the WEBM
container.