### PR TITLE
Disconnect sourcePlayers signal stopped from vfilter/afilter when stopping AVTranscoder

### DIFF
--- a/src/AVTranscoder.cpp
+++ b/src/AVTranscoder.cpp
@@ -286,7 +286,9 @@ void AVTranscoder::stop()
     // uninstall encoder filters first then encoders can be closed safely
     if (sourcePlayer()) {
         sourcePlayer()->uninstallFilter(d->afilter);
+        disconnect(sourcePlayer(), SIGNAL(stopped()), d->afilter, SLOT(finish()));
         sourcePlayer()->uninstallFilter(d->vfilter);
+        disconnect(sourcePlayer(), SIGNAL(stopped()), d->vfilter, SLOT(finish()));
     }
     if (d->afilter)
         d->afilter->finish(); //FIXME: thread of sync mode


### PR DESCRIPTION
The missing disconnect leads to a second call to finish of vfilter/afilter
which then leads to a segmentation fault in sync mode. In async mode
the segmentation fault does not happen because of a race condition
although a second call is executed. Always stop AVTranscoder first and
then the associated AVPlayer.