### PR TITLE
Split audio frames

### DIFF
--- a/src/AudioFormat.cpp
+++ b/src/AudioFormat.cpp
@@ -31,8 +31,6 @@
 
 namespace QtAV {
 
-const qint64 kHz = 1000000LL;
-
 typedef struct {
     AVSampleFormat avfmt;
     AudioFormat::SampleFormat fmt;

--- a/src/AudioFrame.cpp
+++ b/src/AudioFrame.cpp
@@ -180,6 +180,24 @@ AudioFrame AudioFrame::mid(int pos, int len) const
     return f;
 }
 
+void AudioFrame::prepend(AudioFrame &other)
+{
+    Q_D(AudioFrame);
+
+    if (d->format != other.format()) {
+        qWarning() << "To prepend a frame it must have the same audio format";
+        return;
+    }
+
+    d->data.prepend(other.data());
+    d->samples_per_ch += other.samplesPerChannel();
+    d->timestamp = other.timestamp();
+
+    for (int i = 0; i < planeCount(); i++) {
+        d->line_sizes[i] += other.bytesPerLine(i);
+    }
+}
+
 AudioFormat AudioFrame::format() const
 {
     return d_func()->format;

--- a/src/AudioFrame.cpp
+++ b/src/AudioFrame.cpp
@@ -133,22 +133,49 @@ int AudioFrame::channelCount() const
 
 AudioFrame AudioFrame::clone() const
 {
+    return mid(0, -1);
+}
+
+AudioFrame AudioFrame::mid(int pos, int len) const
+{
     Q_D(const AudioFrame);
+
     if (d->format.sampleFormatFFmpeg() == AV_SAMPLE_FMT_NONE
-            || d->format.channels() <= 0)
+            || d->format.channels() <= 0) {
         return AudioFrame();
-    if (d->samples_per_ch <= 0 || bytesPerLine(0) <= 0)
-        return AudioFrame(format());
-    QByteArray buf(bytesPerLine()*planeCount(), 0);
-    char *dst = buf.data(); //must before buf is shared, otherwise data will be detached.
-    for (int i = 0; i < planeCount(); ++i) {
-        const int plane_size = bytesPerLine(i);
-        memcpy(dst, constBits(i), plane_size);
-        dst += plane_size;
     }
+
+    if (d->samples_per_ch <= 0 || bytesPerLine(0) <= 0 || len == 0) {
+        return AudioFrame(format());
+    }
+
+    int bufSize = bytesPerLine();
+    int posBytes = 0;
+    if (pos > 0) {
+        posBytes = pos * d->format.bytesPerSample();
+        bufSize -= posBytes;
+    } else {
+        pos = 0;
+    }
+
+    int lenBytes = len * d->format.bytesPerSample();
+    if (len > 0 && lenBytes < bufSize) {
+        bufSize = lenBytes;
+    } else {
+        lenBytes = bufSize;
+    }
+
+    QByteArray buf(bufSize * planeCount(), 0);
+    char *dst = buf.data(); //must before buf is shared, otherwise data will be detached.
+
+    for (int i = 0; i < planeCount(); ++i) {
+        memcpy(dst, constBits(i) + posBytes, lenBytes);
+        dst += lenBytes;
+    }
+
     AudioFrame f(d->format, buf);
-    f.setSamplesPerChannel(samplesPerChannel());
-    f.setTimestamp(timestamp());
+    f.setSamplesPerChannel(bufSize / d->format.bytesPerSample());
+    f.setTimestamp(d->timestamp + (qreal) d->format.durationForBytes(posBytes) / AudioFormat::kHz);
     // meta data?
     return f;
 }

--- a/src/QtAV/AudioEncoder.h
+++ b/src/QtAV/AudioEncoder.h
@@ -64,6 +64,8 @@ public:
      */
     const AudioFormat& audioFormat() const;
     void setAudioFormat(const AudioFormat& format);
+
+    int frameSize() const;
 Q_SIGNALS:
     void audioFormatChanged();
 public:

--- a/src/QtAV/AudioFormat.h
+++ b/src/QtAV/AudioFormat.h
@@ -68,6 +68,9 @@ public:
         ChannelLayout_Stereo,
         ChannelLayout_Unsupported //ok. now it's not complete
     };
+
+    static const qint64 kHz = 1000000LL;
+
     //typedef qint64 ChannelLayout; //currently use latest FFmpeg's
     // TODO: constexpr
     friend int RawSampleSize(SampleFormat fmt) { return fmt & ((1<<(kSize+1)) - 1); }

--- a/src/QtAV/AudioFrame.h
+++ b/src/QtAV/AudioFrame.h
@@ -58,6 +58,7 @@ public:
      */
     AudioFrame clone() const;
     AudioFrame mid(int pos, int len = -1) const;
+    void prepend(AudioFrame &other);
     AudioFormat format() const;
     void setSamplesPerChannel(int samples);
     // may change after resampling

--- a/src/QtAV/AudioFrame.h
+++ b/src/QtAV/AudioFrame.h
@@ -57,6 +57,7 @@ public:
      * then you can use clone().
      */
     AudioFrame clone() const;
+    AudioFrame mid(int pos, int len = -1) const;
     AudioFormat format() const;
     void setSamplesPerChannel(int samples);
     // may change after resampling

--- a/src/QtAV/private/AVEncoder_p.h
+++ b/src/QtAV/private/AVEncoder_p.h
@@ -71,6 +71,7 @@ class AudioEncoderPrivate : public AVEncoderPrivate
 public:
     AudioEncoderPrivate()
         : AVEncoderPrivate()
+        , frame_size(0)
     {
         bit_rate = 64000;
     }
@@ -79,6 +80,8 @@ public:
 
     AudioResampler *resampler;
     AudioFormat format, format_used;
+
+    int frame_size; // used if avctx->frame_size == 0
 };
 
 class Q_AV_PRIVATE_EXPORT VideoEncoderPrivate : public AVEncoderPrivate

--- a/src/codec/audio/AudioEncoder.cpp
+++ b/src/codec/audio/AudioEncoder.cpp
@@ -80,4 +80,8 @@ const AudioFormat& AudioEncoder::audioFormat() const
     return d_func().format_used;
 }
 
+int AudioEncoder::frameSize() const
+{
+    return d_func().frame_size;
+}
 } //namespace QtAV

--- a/src/codec/audio/AudioEncoderFFmpeg.cpp
+++ b/src/codec/audio/AudioEncoderFFmpeg.cpp
@@ -53,7 +53,6 @@ class AudioEncoderFFmpegPrivate Q_DECL_FINAL: public AudioEncoderPrivate
 public:
     AudioEncoderFFmpegPrivate()
         : AudioEncoderPrivate()
-        , frame_size(0)
     {
         avcodec_register_all();
         // NULL: codec-specific defaults won't be initialized, which may result in suboptimal default settings (this is important mainly for encoders, e.g. libx264).
@@ -62,7 +61,6 @@ public:
     bool open() Q_DECL_OVERRIDE;
     bool close() Q_DECL_OVERRIDE;
 
-    int frame_size; // used if avctx->frame_size == 0
     QByteArray buffer;
 };
 

--- a/src/filter/EncodeFilter.cpp
+++ b/src/filter/EncodeFilter.cpp
@@ -180,7 +180,7 @@ void AudioEncodeFilter::encode(const AudioFrame& frame)
         f.prepend(d.leftOverAudio);
     }
 
-    int frameSizeEncoder = d.enc->frameSize();
+    int frameSizeEncoder = d.enc->frameSize() ? d.enc->frameSize() : f.samplesPerChannel();
     int frameSize = f.samplesPerChannel();
 
     QList<AudioFrame> audioFrames;


### PR DESCRIPTION
Some encoders (e.g. OPUS) define a frame_size for each audio frame
and only process that much data in one encoding step. This means that
the number of incoming frames does not have be equal to the number of
outgoing frames. This patch splits AudioFrames according to the audio
encoders frame_size and buffers the leftovers of a frame until the next
frame arrives and prepends them to it. This results in the decoupling of
incoming and outgoing frame sizes.