### PR TITLE
Set AccessMode of MediaIO according to QIODevice it is created from

### DIFF
--- a/src/AVMuxer.cpp
+++ b/src/AVMuxer.cpp
@@ -341,6 +341,11 @@ bool AVMuxer::setMedia(QIODevice* device)
         d->format_forced.clear();
     }
     d->io->setProperty("device", QVariant::fromValue(device)); //open outside?
+
+    if (device->isWritable()) {
+        d->io->setAccessMode(MediaIO::Write);
+    }
+
     return d->media_changed;
 }
 


### PR DESCRIPTION
When creating MediaIO from QIODevice in AVMuxer's setMedia one had to
manually call mediaIO() after and set the MediaIO's AccessMode to
writable. This patch checks if the QIODevice is writable and then sets
MediaIO's AccessMode automatically.