### PR TITLE
Fix potential reuse of an left over audio frame portion when splitting audio frames

### DIFF
--- a/src/filter/EncodeFilter.cpp
+++ b/src/filter/EncodeFilter.cpp
@@ -178,6 +178,7 @@ void AudioEncodeFilter::encode(const AudioFrame& frame)
 
     if (d.leftOverAudio.isValid()) {
         f.prepend(d.leftOverAudio);
+        d.leftOverAudio = AudioFrame();
     }
 
     int frameSizeEncoder = d.enc->frameSize() ? d.enc->frameSize() : f.samplesPerChannel();


### PR DESCRIPTION
I forgot to delete a left over audio frame portion after prepending it to a new audio frame. This could lead to the potential reuse of that portion and therefore non monotonically increasing dts arriving in the encoder/muxer.