### PR TITLE
Fixes DirectSound crash on Windows 7. When the player is destroyed, P…

### DIFF
--- a/src/QtAV/private/AudioOutputBackend.h
+++ b/src/QtAV/private/AudioOutputBackend.h
@@ -34,7 +34,7 @@ class Q_AV_PRIVATE_EXPORT AudioOutputBackend : public QObject
     Q_OBJECT
 public:
     AudioOutput *audio;
-    bool available; // default is true. set to false when failed to create backend
+    volatile bool available; // default is true. set to false when failed to create backend
     int buffer_size;
     int buffer_count;
     AudioFormat format;

--- a/src/output/audio/AudioOutputDSound.cpp
+++ b/src/output/audio/AudioOutputDSound.cpp
@@ -88,7 +88,7 @@ private:
                     //qWarning("WaitForSingleObjectEx for ao->notify_event error: %#lx", dwResult);
                     continue;
                }
-               ao->onCallback();
+               if (ao->available) ao->onCallback();
             }
         }
     };
@@ -192,6 +192,7 @@ bool AudioOutputDSound::close()
 {
     available = false;
     destroy();
+    SetEvent(notify_event);
     CloseHandle(notify_event); // FIXME: is it ok if thread is still waiting?
     return true;
 }


### PR DESCRIPTION
…ositionWatcher tried to access already destroyed AudioOutputDSound object.