### PR TITLE
OpenGL VideoShader: swap colors when NV21 is used

### DIFF
--- a/src/opengl/VideoShader.cpp
+++ b/src/opengl/VideoShader.cpp
@@ -137,8 +137,12 @@ const char* VideoShader::fragmentShader() const
         return 0;
     }
     const int nb_planes = d.video_format.planeCount();
-    if (nb_planes == 2) //TODO: nv21 must be swapped
+    if (nb_planes == 2) {
         frag.prepend("#define IS_BIPLANE\n");
+        if (d.video_format == VideoFormat::Format_NV21) {
+            frag.prepend("#define IS_NV21\n");
+        }
+    }
     if (OpenGLHelper::hasRG() && !OpenGLHelper::useDeprecatedFormats())
         frag.prepend("#define USE_RG\n");
     const bool has_alpha = d.video_format.hasAlpha();

--- a/src/shaders/planar.f.glsl
+++ b/src/shaders/planar.f.glsl
@@ -70,17 +70,27 @@ void main()
 #else
 #ifdef USE_RG
                              sample2d(u_Texture0, v_TexCoords0, 0).r,
-                             sample2d(u_Texture1, v_TexCoords1, 1).r,
 #ifdef IS_BIPLANE
-                             sample2d(u_Texture2, v_TexCoords2, 2).g,
+#ifdef IS_NV21
+                             sample2d(u_Texture1, v_TexCoords1, 1).g,
+                             sample2d(u_Texture2, v_TexCoords2, 2).r,
 #else
+                             sample2d(u_Texture1, v_TexCoords1, 1).r,
+                             sample2d(u_Texture2, v_TexCoords2, 2).g,
+#endif //IS_NV21
+#else
+                             sample2d(u_Texture1, v_TexCoords1, 1).r,
                              sample2d(u_Texture2, v_TexCoords2, 2).r,
 #endif //IS_BIPLANE
 #else
-// use r, g, a to work for both yv12 and nv12. idea from xbmc
+// use r, g, a/r to work for both yv12 and nv12/nv21. idea from xbmc
                              sample2d(u_Texture0, v_TexCoords0, 0).r,
                              sample2d(u_Texture1, v_TexCoords1, 1).g,
+#ifdef IS_NV21
+                             sample2d(u_Texture2, v_TexCoords2, 2).r,
+#else
                              sample2d(u_Texture2, v_TexCoords2, 2).a,
+#endif //IS_NV21
 #endif //USE_RG
 #endif //CHANNEL16_TO8
                              1.0


### PR DESCRIPTION
As the title says, swap colors when the video format is NV21 so colors are displayed correctly