### PR TITLE
Remove usage of deprecated avfiltergraph.h header

### DIFF
--- a/src/QtAV/private/AVCompat.h
+++ b/src/QtAV/private/AVCompat.h
@@ -59,6 +59,7 @@ extern "C"
 #include <libavutil/parseutils.h>
 #include <libavutil/pixdesc.h>
 #include <libavutil/avstring.h>
+#include <libavfilter/version.h>
 
 #if !FFMPEG_MODULE_CHECK(LIBAVUTIL, 51, 73, 101)
 #include <libavutil/channel_layout.h>
@@ -79,8 +80,11 @@ extern "C"
 #endif //QTAV_HAVE(AVRESAMPLE)
 
 #if QTAV_HAVE(AVFILTER)
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,8,0)
 #include <libavfilter/avfiltergraph.h> /*code is here for old version*/
+#else
 #include <libavfilter/avfilter.h>
+#endif
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #endif //QTAV_HAVE(AVFILTER)


### PR DESCRIPTION
avfiltergraph.h was replaced by avfilter.h in libavfilter version
3.8.0+ so only include it when the used libavfilter version
is older than 3.8.0

This allows to build with ffmpeg master from commit
f5950b8fd61ec85e0ad8790bea56b37ceea19436 onwards
in which avfiltergraph.h was removed.