### PR TITLE
Fix QML plugin not being found on iOS

### DIFF
--- a/qml/libQmlAV.pro
+++ b/qml/libQmlAV.pro
@@ -13,10 +13,17 @@ PROJECTROOT = $$PWD/..
 preparePaths($$OUT_PWD/../out)
 #https://github.com/wang-bin/QtAV/issues/368#issuecomment-73246253
 #http://qt-project.org/forums/viewthread/38438
-# mkspecs/features/qml_plugin.prf
-URI = QtAV #uri used in QtAVQmlPlugin::registerTypes(uri)
-qtAtLeast(5, 3): QMAKE_MOC_OPTIONS += -Muri=$$URI # not sure what moc does
-#DESTDIR = $$BUILD_DIR/bin/QtAV
+# mkspecs/features/qml_plugin.prf mkspecs/features/qml_module.prf
+TARGETPATH = QtAV
+URI = $$replace(TARGETPATH, "/", ".")
+QMAKE_MOC_OPTIONS += -Muri=$$URI
+
+static: CONFIG += builtin_resources
+
+builtin_resources {
+    RESOURCES += libQmlAV.qrc
+}
+
 qtav_qml.files = qmldir Video.qml plugins.qmltypes
 !static { #static lib copy error before ranlib. copy only in sdk_install
   plugin.files = $$DESTDIR/$$qtSharedLib($$NAME)

--- a/qml/libQmlAV.pro
+++ b/qml/libQmlAV.pro
@@ -16,7 +16,7 @@ preparePaths($$OUT_PWD/../out)
 # mkspecs/features/qml_plugin.prf mkspecs/features/qml_module.prf
 TARGETPATH = QtAV
 URI = $$replace(TARGETPATH, "/", ".")
-QMAKE_MOC_OPTIONS += -Muri=$$URI
+qtAtLeast(5, 3): QMAKE_MOC_OPTIONS += -Muri=$$URI
 
 static: CONFIG += builtin_resources
 

--- a/qml/libQmlAV.qrc
+++ b/qml/libQmlAV.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/qt-project.org/imports/QtAV">
+        <file>qmldir</file>
+        <file>Video.qml</file>
+    </qresource>
+</RCC>

--- a/qml/plugin.cpp
+++ b/qml/plugin.cpp
@@ -32,6 +32,12 @@
 #include "QmlAV/QuickFBORenderer.h"
 #endif
 
+inline void initResources() {
+#ifdef BUILD_QMLAV_STATIC
+    Q_INIT_RESOURCE(libQmlAV);
+#endif
+}
+
 namespace QtAV {
 
 class QtAVQmlPlugin : public QQmlExtensionPlugin
@@ -39,6 +45,9 @@ class QtAVQmlPlugin : public QQmlExtensionPlugin
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QQmlExtensionInterface")
 public:
+    QtAVQmlPlugin() {
+        initResources();
+    }
     void registerTypes(const char *uri)
     {
         Q_ASSERT(QLatin1String(uri) == QLatin1String("QtAV"));


### PR DESCRIPTION
When a QML plugin is used as a static library, the qml engine
searches for a qmldir in qrc:/qt-project.org/imports/<ModuleName>

This adds a qrc file to do that and ensure it is initialized for static builds.

Fixes #997 

In theory it seems possible to generate a .qrc from the qmake in the .pro (see qml_module.prf and resources.prf), but I couldn't make it work so I harcoded an actual .qrc file.