### PR TITLE
Updating alignment to fix image capture.

### DIFF
--- a/src/ImageConverter.cpp
+++ b/src/ImageConverter.cpp
@@ -216,7 +216,7 @@ bool ImageConverter::prepareData()
     d.bits.resize(nb_planes);
     d.pitchs.resize(nb_planes);
     // alignment is 16. sws in ffmpeg is 16, libav10 is 8
-    const int kAlign = 16;
+    const int kAlign = 8;
     AV_ENSURE(av_image_fill_linesizes((int*)d.pitchs.constData(), d.fmt_out, kAlign > 7 ? FFALIGN(d.w_out, 8) : d.w_out), false);
     for (int i = 0; i < d.pitchs.size(); ++i)
         d.pitchs[i] = FFALIGN(d.pitchs[i], kAlign);


### PR DESCRIPTION
QtAV::VideoFrame::toImage was creating images with distortion in the first vertical column of pixels. See the attached image as an example. I was able to resolve this by changing the kAlign value in this code. But I don't understand well enough to update the comment above.

![image](https://user-images.githubusercontent.com/5105729/35949334-d1b9fd56-0c25-11e8-8ea6-8b25a04911ec.png)
