### PR TITLE
Clearing packetqueue and setting clock from avdemux thread.

### DIFF
--- a/src/AVDemuxThread.h
+++ b/src/AVDemuxThread.h
@@ -46,7 +46,7 @@ public:
     AVThread* videoThread();
     void stepForward(); // show next video frame and pause
     void stepBackward();
-    void seek(qint64 pos, SeekType type); //ms
+    void seek(qint64 external_pos, qint64 pos, SeekType type); //ms
     //AVDemuxer* demuxer
     bool isPaused() const;
     bool isEnd() const;
@@ -84,7 +84,7 @@ private:
     void setAVThread(AVThread *&pOld, AVThread* pNew);
     void newSeekRequest(QRunnable *r);
     void processNextSeekTask();
-    void seekInternal(qint64 pos, SeekType type); //must call in AVDemuxThread
+    void seekInternal(qint64 pos, SeekType type, qint64 external_pos = std::numeric_limits < qint64 >::min()); //must call in AVDemuxThread
     void pauseInternal(bool value);
 
     bool paused;

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -858,13 +858,11 @@ void AVPlayer::setPosition(qint64 position)
     qint64 pos_pts = position;
     if (pos_pts < 0)
         pos_pts = 0;
-    masterClock()->updateExternalClock(pos_pts); //in msec. ignore usec part using t/1000
     // position passed in is relative to the start pts in relative time mode
     if (relativeTimeMode())
         pos_pts += absoluteMediaStartPosition();
     d->seeking = true;
-    masterClock()->updateValue(double(pos_pts)/1000.0); //what is duration == 0
-    d->read_thread->seek(pos_pts, seekType());
+    d->read_thread->seek(position,pos_pts, seekType());
 
     Q_EMIT positionChanged(position); //emit relative position
 }


### PR DESCRIPTION
If the packetqueue was cleared in the seek function then it can happen that
seek clears the packetqueue, then the other thread puts an other packet
with high timestamp and videothread takes it. In this case the videothread
waits a lot and video just freezes. This was fixed by putting the clear
into the SeekTask's run function. When I fixed this I realized that the
clock is sometimes wrong,too, so I put the clock updates into the SeekTask,
too. I am not sure if this is the perfect solution to make videothread's
waitAndCheck always work correctly, but it's definitely improved.