### PR TITLE
Loop until frame buffer is full.

### DIFF
--- a/src/FrameReader.cpp
+++ b/src/FrameReader.cpp
@@ -353,7 +353,7 @@ void FrameReader::readMoreInternal()
             d->vframes.put(frame);
             Q_EMIT frameRead(frame);
             //qDebug("frame got @%.3f, queue enough: %d", frame.timestamp(), vframes.isEnough());
-            if (d->vframes.isEnough())
+            if (d->vframes.isFull())
                 break;
         } else {
             qDebug("dec error, continue to decoder");


### PR DESCRIPTION
In the original code, the framereader loops until the buffer is "full
enough" and will never be full.