### PR TITLE
Use Qt::QueuedConnection for FrameReader signals.

### DIFF
--- a/src/FrameReader.cpp
+++ b/src/FrameReader.cpp
@@ -251,9 +251,9 @@ FrameReader::FrameReader(QObject *parent)
     , d(new Private())
 {
     moveToThread(&d->read_thread);
-    connect(this, SIGNAL(readMoreRequested()), SLOT(readMoreInternal()));
+    connect(this, SIGNAL(readMoreRequested()), SLOT(readMoreInternal()), Qt::QueuedConnection);
     connect(this, SIGNAL(readEnd()), &d->read_thread, SLOT(quit()));
-    connect(this, SIGNAL(seekRequested(qint64)), SLOT(seekInternal(qint64)));
+    connect(this, SIGNAL(seekRequested(qint64)), SLOT(seekInternal(qint64)), Qt::QueuedConnection);
 }
 
 FrameReader::~FrameReader()


### PR DESCRIPTION
If I understand the meaning of the code in FrameReader correctly, the
readMoreInternal and seekInternal methods should run on the read_thread.
However, due to the fact that the connection is made from this to this,
the connection is a Qt::DirectConnection, which means that the slots
will be executed on the thread that is emitting the signal. See
https://doc.qt.io/qt-5/threads-qobject.html#signals-and-slots-across-threads

It could be that I am mistaken about the intention of the code, but I
was surprised to see that the frame reading did not occur on the
reader_thread.