### PR TITLE
Update Subtitle.cpp

### DIFF
--- a/src/subtitle/Subtitle.cpp
+++ b/src/subtitle/Subtitle.cpp
@@ -501,9 +501,14 @@ QString Subtitle::getText() const
     priv->current_text.clear();
     const int count = qAbs(priv->current_count);
     QLinkedList<SubtitleFrame>::iterator it = priv->current_count > 0 ? priv->itf : priv->itf + (priv->current_count+1);
-    for (int i = 0; i < count; ++i) {
-        priv->current_text.append(it->text).append(QStringLiteral("\n"));
-        ++it;
+
+    for (int i = 0; i < count; ++i) {        
+        if(priv->current_text.startsWith(it->text)){
+            break;
+        } else {
+            priv->current_text.append(it->text).append(QStringLiteral("\n"));
+            ++it;
+        }
     }
     priv->current_text = priv->current_text.trimmed();
     return priv->current_text;


### PR DESCRIPTION
For embedded subtitles in video files, skipping produces multiple subtitle objects on the screen make an illusion of repeated subtitles.
To prevent this, the changes in above code, accounts for the previous frame and check whether the previous and current text are the same or  they differ.
If the text differ, it updates the subtitle, if the same, it ignores it.
There might be a better way to fix this, but, this is what i can do currently with my little knowledge on workings of QtAV library.