### PR TITLE
Fixed Qt header misspelling: QTableWidget -> QTabWidget.

### DIFF
--- a/widgets/global.cpp
+++ b/widgets/global.cpp
@@ -24,7 +24,7 @@
 #include <QBoxLayout>
 #include <QMessageBox>
 #include <QPushButton>
-#include <QTableWidget>
+#include <QTabWidget>
 #include <QTextBrowser>
 
 #include "QtAVWidgets/WidgetRenderer.h"


### PR DESCRIPTION
您把Qt头文件的名字拼错了，导致引入了另一个根本没有用到的Widget的依赖。我读了源码之后，感觉应该改为QTabWidget。