### PR TITLE
BugFix:  fix the file maybe play error when play the top frames

### DIFF
--- a/src/AVPlayerPrivate.cpp
+++ b/src/AVPlayerPrivate.cpp
@@ -428,6 +428,10 @@ bool AVPlayer::Private::setupAudioThread(AVPlayer *player)
             }
         }
     }
+
+    // we set the thre state before the thread start,
+    // as it maybe clear after by AVDemuxThread starting
+    athread->resetState();
     athread->setDecoder(adec);
     setAVOutput(ao, ao, athread);
     updateBufferValue(athread->packetQueue());
@@ -605,6 +609,10 @@ bool AVPlayer::Private::setupVideoThread(AVPlayer *player)
         }
         QObject::connect(vthread, SIGNAL(finished()), player, SLOT(tryClearVideoRenderers()), Qt::DirectConnection);
     }
+
+    // we set the thre state before the thread start
+    // as it maybe clear after by AVDemuxThread starting
+    vthread->resetState();
     vthread->setDecoder(vdec);
 
     vthread->setBrightness(brightness);

--- a/src/AVThread.h
+++ b/src/AVThread.h
@@ -81,6 +81,7 @@ public:
     qreal decodeFrameRate() const; //move to statistics?
     void setDropFrameOnSeek(bool value);
 
+    void resetState();
 public slots:
     virtual void stop();
     /*change pause state. the pause/continue action will do in the next loop*/
@@ -100,7 +101,6 @@ private Q_SLOTS:
     void onFinished();
 protected:
     AVThread(AVThreadPrivate& d, QObject *parent = 0);
-    void resetState();
     /*
      * If the pause state is true setted by pause(true), then block the thread and wait for pause state changed, i.e. pause(false)
      * and return true. Otherwise, return false immediatly.

--- a/src/AudioThread.cpp
+++ b/src/AudioThread.cpp
@@ -78,7 +78,7 @@ void AudioThread::run()
     //No decoder or output. No audio output is ok, just display picture
     if (!d.dec || !d.dec->isAvailable() || !d.outputSet)
         return;
-    resetState();
+    // resetState(); // we can't reset the thread state from here
     Q_ASSERT(d.clock != 0);
     d.init();
     Packet pkt;

--- a/src/VideoThread.cpp
+++ b/src/VideoThread.cpp
@@ -243,7 +243,7 @@ void VideoThread::run()
     DPTR_D(VideoThread);
     if (!d.dec || !d.dec->isAvailable() || !d.outputSet)
         return;
-    resetState();
+    // resetState(); // we can't reset the thread state from here
     if (d.capture->autoSave()) {
         d.capture->setCaptureName(QFileInfo(d.statistics->url).completeBaseName());
     }
@@ -320,7 +320,7 @@ void VideoThread::run()
             if (!pkt.isValid()) {
                 // may be we should check other information. invalid packet can come from
                 wait_key_frame = true;
-                qDebug("Invalid packet! flush video codec context!!!!!!!!!! video packet queue size: %d", d.packets.size());  
+                qDebug("Invalid packet! flush video codec context!!!!!!!!!! video packet queue size: %d", d.packets.size());
                 d.dec->flush(); //d.dec instead of dec because d.dec maybe changed in processNextTask() but dec is not
                 d.render_pts0 = pkt.pts;
                 sync_id = pkt.position;


### PR DESCRIPTION
when the AVDemuxThread run before the AudioThread / VideoThread , It will read the Audio/Video Packets, while the AudioThread/VideoThread will execute the resetState() if it''s contained run() of the thread.