### PR TITLE
Add support for managing subtitle tracks from qml

### DIFF
--- a/qml/Video.qml
+++ b/qml/Video.qml
@@ -89,6 +89,8 @@ Item {
     property alias internalAudioTracks: player.internalAudioTracks
     property alias externalAudioTracks: player.externalAudioTracks
     property alias internalVideoTracks: player.internalVideoTracks
+    property alias internalSubtitleTracks: player.internalSubtitleTracks
+    property alias internalSubtitleTrack: player.internalSubtitleTrack
     /*** Properties of VideoOutput ***/
     /*!
         \qmlproperty enumeration Video::fillMode


### PR DESCRIPTION
I think those 2 aliases was just missing or forgotten,
with this patch subtitles are fully usable from QML