### PR TITLE
修复计算溢出导致的播放卡顿以及播放无音频流的在线视频卡住不能播放的问题

### DIFF
--- a/src/AVPlayerPrivate.cpp
+++ b/src/AVPlayerPrivate.cpp
@@ -197,7 +197,7 @@ void AVPlayer::Private::applyFrameRate()
         force = !!vthread;
         vfps = statistics.video.frame_rate > 0 ? statistics.video.frame_rate : 25;
         // vfps<0: try to use pts (ExternalClock). if no pts (raw codec), try the default fps(VideoClock)
-        vfps = -vfps;
+        //vfps = -vfps;
     }
     qreal r = speed;
     if (force) {

--- a/src/AVThread.cpp
+++ b/src/AVThread.cpp
@@ -366,7 +366,12 @@ void AVThread::waitAndCheck(ulong value, qreal pts)
     DPTR_D(AVThread);
     if (value <= 0 || pts < 0)
         return;
-    value += d.wait_err;
+
+	if (d.wait_err < 0 && abs(d.wait_err) >= value)
+		value = 0;
+	else
+		value += d.wait_err;
+
     d.wait_timer.restart();
     //qDebug("wating for %lu msecs", value);
     ulong us = value * 1000UL;


### PR DESCRIPTION
src/AVThread.cpp 
修复计算溢出导致的播放卡顿问题。
src/AVPlayerPrivate.cpp
播放vlc推流的不含音频的纯视频流时，发现了显示几帧后就会卡住不动的问题，改了这里就没问题了。但是不知道有没有别的风险。