### PR TITLE
Skip speed and display fix

### DIFF
--- a/src/AVDemuxThread.cpp
+++ b/src/AVDemuxThread.cpp
@@ -160,7 +160,7 @@ void AVDemuxThread::stepBackward()
 {
     if (!video_thread)
         return;
-    if (hasSeekTasks() || m_buffering)
+    if (hasSeekTasks())
         return;
     AVThread *t = video_thread;
     const qreal pre_pts = video_thread->previousHistoryPts();
@@ -469,7 +469,7 @@ void AVDemuxThread::stepForward()
 {
     if (end)
         return;
-    if (hasSeekTasks() || m_buffering)
+    if (hasSeekTasks())
         return;
 
     stepping = true;

--- a/src/AVDemuxThread.cpp
+++ b/src/AVDemuxThread.cpp
@@ -272,7 +272,7 @@ void AVDemuxThread::seek(qint64 external_pos, qint64 pos, SeekType type)
     };
 
     end = false;
-    // queue maybe blocked by put()	
+    // queue maybe blocked by put()
     // These must be here or seeking while paused will not update the video frame
     if (audio_thread) {
         audio_thread->packetQueue()->clear();

--- a/src/AVDemuxThread.cpp
+++ b/src/AVDemuxThread.cpp
@@ -364,7 +364,7 @@ bool AVDemuxThread::hasSeekTasks()
     if (stepping && stepping_timeout_time > 0 && stepping_timeout_time < QDateTime::currentMSecsSinceEpoch()) {
         finishedStepBackward();
     }
-	return !seek_tasks.isEmpty() || current_seek_task || stepping;
+    return !seek_tasks.isEmpty() || current_seek_task || stepping;
 }
 
 qint64 AVDemuxThread::lastSeekPos()

--- a/src/AVDemuxThread.h
+++ b/src/AVDemuxThread.h
@@ -100,6 +100,7 @@ private:
     QMutex buffer_mutex;
     QWaitCondition cond;
     BlockingQueue<QRunnable*> seek_tasks;
+    qint64 last_seek_pos;
 
     QSemaphore sem;
     QMutex next_frame_mutex;

--- a/src/AVDemuxThread.h
+++ b/src/AVDemuxThread.h
@@ -27,6 +27,7 @@
 #include <QtCore/QThread>
 #include <QtCore/QRunnable>
 #include "PacketBuffer.h"
+#include <QTimer>
 
 namespace QtAV {
 
@@ -60,6 +61,7 @@ public:
     void setMediaEndAction(MediaEndAction value);
     bool waitForStarted(int msec = -1);
 	qint64 lastSeekPos();
+	bool hasSeekTasks();
 Q_SIGNALS:
     void requestClockPause(bool value);
     void mediaStatusChanged(QtAV::MediaStatus);
@@ -68,9 +70,11 @@ Q_SIGNALS:
     void stepFinished();
     void internalSubtitlePacketRead(int index, const QtAV::Packet& packet);
 private slots:
+    void finishedStepBackward();
     void seekOnPauseFinished();
     void frameDeliveredOnStepForward();
     void eofDecodedOnStepForward();
+    void stepForwardDone();
     void onAVThreadQuit();
 
 protected:
@@ -102,7 +106,10 @@ private:
     QWaitCondition cond;
     BlockingQueue<QRunnable*> seek_tasks;
     qint64 last_seek_pos;
-
+    QRunnable *current_seek_task;
+    bool stepping;
+    QTimer *step_timeout_timer;
+        
     QSemaphore sem;
     QMutex next_frame_mutex;
     int clock_type; // change happens in different threads(direct connection)

--- a/src/AVDemuxThread.h
+++ b/src/AVDemuxThread.h
@@ -59,6 +59,7 @@ public:
     MediaEndAction mediaEndAction() const;
     void setMediaEndAction(MediaEndAction value);
     bool waitForStarted(int msec = -1);
+	qint64 lastSeekPos();
 Q_SIGNALS:
     void requestClockPause(bool value);
     void mediaStatusChanged(QtAV::MediaStatus);

--- a/src/AVDemuxThread.h
+++ b/src/AVDemuxThread.h
@@ -108,7 +108,7 @@ private:
     qint64 last_seek_pos;
     QRunnable *current_seek_task;
     bool stepping;
-    QTimer *step_timeout_timer;
+    qint64 stepping_timeout_time;
         
     QSemaphore sem;
     QMutex next_frame_mutex;

--- a/src/AVDemuxThread.h
+++ b/src/AVDemuxThread.h
@@ -60,8 +60,8 @@ public:
     MediaEndAction mediaEndAction() const;
     void setMediaEndAction(MediaEndAction value);
     bool waitForStarted(int msec = -1);
-	qint64 lastSeekPos();
-	bool hasSeekTasks();
+    qint64 lastSeekPos();
+    bool hasSeekTasks();
 Q_SIGNALS:
     void requestClockPause(bool value);
     void mediaStatusChanged(QtAV::MediaStatus);

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -583,6 +583,12 @@ void AVPlayer::pause(bool p)
         return;
     if (isPaused() == p)
         return;
+
+    if (!p) {
+        // TODO: If was stepping, skip our position a little bit behind us.
+        d->was_stepping = false;
+    }
+
     audio()->pause(p);
     //pause thread. check pause state?
     d->read_thread->pause(p);
@@ -850,17 +856,19 @@ qint64 AVPlayer::position() const
 
 qint64 AVPlayer::displayPosition() const
 {
-    //return d->read_thread->lastSeekPos();
-
 	// Return a cached value if there are seek tasks
-	if (d->seeking || (d->read_thread->buffer() && d->read_thread->buffer()->isBuffering())) {
-		//return d->last_known_good_pts;
+	if (d->seeking || d->read_thread->hasSeekTasks() || (d->read_thread->buffer() && d->read_thread->buffer()->isBuffering())) {
 		return d->last_known_good_pts = d->read_thread->lastSeekPos();
 	}
 
 	// TODO: videoTime()?
 	qint64 pts = d->clock->videoTime()*1000.0;
 
+    // If we are stepping around, we want the lastSeekPos.
+    /// But if we're just paused by the user... we want another value.
+    if (d->was_stepping) {
+        pts = d->read_thread->lastSeekPos();
+    }
 	if (pts < 0) {
 		return d->last_known_good_pts;
 	}
@@ -1279,6 +1287,9 @@ void AVPlayer::playInternal()
         else
             setPosition((qint64)(d->start_position_norm));
     }
+    
+    d->was_stepping = false;
+
     Q_EMIT stateChanged(PlayingState);
     Q_EMIT started(); //we called stop(), so must emit started()
 }
@@ -1561,12 +1572,14 @@ void AVPlayer::stepForward()
 {
     // pause clock
     pause(true); // must pause AVDemuxThread (set user_paused true)
+    d->was_stepping = true;
     d->read_thread->stepForward();
 }
 
 void AVPlayer::stepBackward()
 {
 	pause(true);
+    d->was_stepping = true;
 	d->read_thread->stepBackward();
 }
 

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -860,25 +860,25 @@ qint64 AVPlayer::position() const
 
 qint64 AVPlayer::displayPosition() const
 {
-	// Return a cached value if there are seek tasks
-	if (d->seeking || d->read_thread->hasSeekTasks() || (d->read_thread->buffer() && d->read_thread->buffer()->isBuffering())) {
-		return d->last_known_good_pts = d->read_thread->lastSeekPos();
-	}
+    // Return a cached value if there are seek tasks
+    if (d->seeking || d->read_thread->hasSeekTasks() || (d->read_thread->buffer() && d->read_thread->buffer()->isBuffering())) {
+        return d->last_known_good_pts = d->read_thread->lastSeekPos();
+    }
 
-	// TODO: videoTime()?
-	qint64 pts = d->clock->videoTime()*1000.0;
+    // TODO: videoTime()?
+    qint64 pts = d->clock->videoTime()*1000.0;
 
     // If we are stepping around, we want the lastSeekPos.
     /// But if we're just paused by the user... we want another value.
     if (d->was_stepping) {
         pts = d->read_thread->lastSeekPos();
     }
-	if (pts < 0) {
-		return d->last_known_good_pts;
-	}
-	d->last_known_good_pts = pts;
+    if (pts < 0) {
+        return d->last_known_good_pts;
+    }
+    d->last_known_good_pts = pts;
 
-	return pts;
+    return pts;
 }
 
 void AVPlayer::setPosition(qint64 position)
@@ -1582,9 +1582,9 @@ void AVPlayer::stepForward()
 
 void AVPlayer::stepBackward()
 {
-	pause(true);
+    pause(true);
     d->was_stepping = true;
-	d->read_thread->stepBackward();
+    d->read_thread->stepBackward();
 }
 
 void AVPlayer::seek(qreal r)

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -1545,11 +1545,8 @@ void AVPlayer::stepForward()
 
 void AVPlayer::stepBackward()
 {
-    d->clock->pause(true);
-    d->state = PausedState;
-    Q_EMIT stateChanged(d->state);
-    Q_EMIT paused(true);
-    d->read_thread->stepBackward();
+	pause(true);
+	d->read_thread->stepBackward();
 }
 
 void AVPlayer::seek(qreal r)

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -585,8 +585,12 @@ void AVPlayer::pause(bool p)
         return;
 
     if (!p) {
-        // TODO: If was stepping, skip our position a little bit behind us.
-        d->was_stepping = false;
+        if (d->was_stepping) {
+            d->was_stepping = false;
+            // If was stepping, skip our position a little bit behind us.
+            //  This fixes an issue with the audio timer
+            seek(position() - 100);
+        }
     }
 
     audio()->pause(p);

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -848,6 +848,27 @@ qint64 AVPlayer::position() const
     return pts;
 }
 
+qint64 AVPlayer::displayPosition() const
+{
+    //return d->read_thread->lastSeekPos();
+
+	// Return a cached value if there are seek tasks
+	if (d->seeking || (d->read_thread->buffer() && d->read_thread->buffer()->isBuffering())) {
+		//return d->last_known_good_pts;
+		return d->last_known_good_pts = d->read_thread->lastSeekPos();
+	}
+
+	// TODO: videoTime()?
+	qint64 pts = d->clock->videoTime()*1000.0;
+
+	if (pts < 0) {
+		return d->last_known_good_pts;
+	}
+	d->last_known_good_pts = pts;
+
+	return pts;
+}
+
 void AVPlayer::setPosition(qint64 position)
 {
     // FIXME: strange things happen if seek out of eof

--- a/src/AVPlayerPrivate.cpp
+++ b/src/AVPlayerPrivate.cpp
@@ -111,6 +111,7 @@ AVPlayer::Private::Private()
     , status(NoMedia)
     , state(AVPlayer::StoppedState)
     , end_action(MediaEndAction_Default)
+    , last_known_good_pts(0)
 {
     demuxer.setInterruptTimeout(interrupt_timeout);
     /*

--- a/src/AVPlayerPrivate.cpp
+++ b/src/AVPlayerPrivate.cpp
@@ -112,6 +112,7 @@ AVPlayer::Private::Private()
     , state(AVPlayer::StoppedState)
     , end_action(MediaEndAction_Default)
     , last_known_good_pts(0)
+    , was_stepping(false)
 {
     demuxer.setInterruptTimeout(interrupt_timeout);
     /*

--- a/src/AVPlayerPrivate.h
+++ b/src/AVPlayerPrivate.h
@@ -111,7 +111,7 @@ public:
     bool reset_state;
     qint64 start_position, stop_position;
     qint64 start_position_norm, stop_position_norm; // real position
-	qint64 last_known_good_pts;
+    qint64 last_known_good_pts;
     bool was_stepping;
     int repeat_max, repeat_current;
     int timer_id; //notify position change and check AB repeat range. active when playing

--- a/src/AVPlayerPrivate.h
+++ b/src/AVPlayerPrivate.h
@@ -112,6 +112,7 @@ public:
     qint64 start_position, stop_position;
     qint64 start_position_norm, stop_position_norm; // real position
 	qint64 last_known_good_pts;
+    bool was_stepping;
     int repeat_max, repeat_current;
     int timer_id; //notify position change and check AB repeat range. active when playing
 

--- a/src/AVPlayerPrivate.h
+++ b/src/AVPlayerPrivate.h
@@ -111,6 +111,7 @@ public:
     bool reset_state;
     qint64 start_position, stop_position;
     qint64 start_position_norm, stop_position_norm; // real position
+	qint64 last_known_good_pts;
     int repeat_max, repeat_current;
     int timer_id; //notify position change and check AB repeat range. active when playing
 

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -178,7 +178,8 @@ public:
      */
     qint64 stopPosition() const; //unit: ms
     qint64 position() const; //unit: ms
-    //0: play once. N: play N+1 times. <0: infinity
+	qint64 displayPosition() const;
+	//0: play once. N: play N+1 times. <0: infinity
     int repeat() const; //or repeatMax()?
     /*!
      * \brief currentRepeat

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -178,8 +178,8 @@ public:
      */
     qint64 stopPosition() const; //unit: ms
     qint64 position() const; //unit: ms
-	qint64 displayPosition() const;
-	//0: play once. N: play N+1 times. <0: infinity
+    qint64 displayPosition() const;
+    //0: play once. N: play N+1 times. <0: infinity
     int repeat() const; //or repeatMax()?
     /*!
      * \brief currentRepeat


### PR DESCRIPTION
I wrote this code a while ago to fix an issue with skipping forward messing with the audio timer.
See #1029 

These are probably hacky fixes. But they worked for my project.

* Don't allow the user to step when they are already stepping.
* This adds a `stepping_timeout_time` since I would get into situations where the code thought it was still stepping, but it wasn't ever going to finish.
* I also added a `AVPlayer::displayPosition` which felt more accurate than `AVPlayer::position` which tends to jump around a lot while skipping, this would be weird to watch in the UI.
* If we were previously stepping backwards and hit play, seek a little bit backwards to fix up the clock before playing.

This code, along with setting the player clock to `AVClock::ExternalClock` fixed my skipping issues.
```
+    connect(m_player, &AVPlayer::started, [this](){
+        m_player->masterClock()->setClockAuto(false); m_player->masterClock()->setClockType(QtAV::AVClock::ExternalClock);
+    });
```
