### PR TITLE
Fix video flickering

### DIFF
--- a/src/VideoThread.cpp
+++ b/src/VideoThread.cpp
@@ -506,7 +506,6 @@ void VideoThread::run()
                     break;
             }
             pkt = Packet();
-            v_a = 0; //?
             continue;
         }
         // reduce here to ensure to decode the rest data in the next loop
@@ -519,7 +518,6 @@ void VideoThread::run()
                 pkt = Packet();
             else
                 pkt_data = pkt.data.constData();
-            v_a = 0; //?
             continue;
         }
         pkt_data = pkt.data.constData();


### PR DESCRIPTION
Playing some videos which seem to contain invalid frames results in annoying flickering becouse a_v gets vanished each time a frame cannot be decoded.

For example, the archive [examples.zip](https://github.com/wang-bin/QtAV/files/4049515/examples.zip)
contains two webm videos. The origin.webm is correcly played by ffplay or any other players but flickers in QtAV players (Player.exe, QMLPlayer.exe or a simple cutom project using Video.qml). The coded.webm has been coded via ffmpeg and it works fine in all players.