### PR TITLE
Possible fix for crash that occurred when external monitor was (un)plugged

### DIFF
--- a/src/opengl/OpenGLVideo.cpp
+++ b/src/opengl/OpenGLVideo.cpp
@@ -392,7 +392,10 @@ void OpenGLVideo::updateViewport()
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     QSizeF surfaceSize = d.ctx->surface()->size();
 #if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-    surfaceSize *= d.ctx->screen()->devicePixelRatio();
+    // When changing monitors (plugging and unplugging), the screen might sometimes be nullptr!
+    if (d.ctx->screen()) {
+        surfaceSize *= d.ctx->screen()->devicePixelRatio();
+    }
 #else
     surfaceSize *= qApp->devicePixelRatio(); //TODO: window()->devicePixelRatio() is the window screen's
 #endif


### PR DESCRIPTION
This crash was only found on MacOS, on certain MacBooks.

When a HDMI monitor was plugged in, or unplugged, the crash would sometimes occur. Below is the MacOS crash log:

```
Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000008
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [18715]

VM Regions Near 0x8:
--> 
    __TEXT                 000000010a561000-000000010a9bc000 [ 4460K] r-x/r-x SM=COW  /Applications/BRVR/*/BigRingVR.app/Contents/MacOS/BigRingVR

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   org.qt-project.QtGui          	0x000000010bf82409 QScreen::devicePixelRatio() const + 9
1   com.yourcompany.QtAV          	0x000000010ae41b23 QtAV::OpenGLVideo::updateViewport() + 83
2   org.qt-project.QtCore         	0x000000010cad006f QMetaObject::activate(QObject*, int, int, void**) + 2319
3   org.qt-project.QtGui          	0x000000010bf583df QGuiApplication::primaryScreenChanged(QScreen*) + 63
4   org.qt-project.QtGui          	0x000000010bf35c63 QWindowSystemInterface::handleScreenAdded(QPlatformScreen*, bool) + 531
5   libqcocoa.dylib               	0x000000010f8609ab 0x10f855000 + 47531
6   libqcocoa.dylib               	0x000000010f8648c5 0x10f855000 + 63685
7   com.apple.SkyLight            	0x00007fff5aabaf66 displayConfigFinalizedProc + 23
```

By checking if `d.ctx->screen()` is `nullptr`, the crash can be prevented.