### PR TITLE
Fix make install with alernate root path

### DIFF
--- a/deploy.pri
+++ b/deploy.pri
@@ -4,7 +4,7 @@ INSTALL_PREFIX = /usr/local
 share.files = $$PROJECTROOT/qtc_packaging/common/changelog \
 			$$PROJECTROOT/qtc_packaging/common/copyright \
 			$$PROJECTROOT/qtc_packaging/common/README
-share.path = /usr/share/doc/$${TARGET}
+share.path = $$[QT_INSTALL_PREFIX]/share/doc/$${TARGET}
 
 isEqual(TEMPLATE, app) {
 	unix:!symbian {
@@ -12,22 +12,22 @@ isEqual(TEMPLATE, app) {
 			DEFINES += CACHE_APPDIR
 			INSTALL_PREFIX = /opt/$${TARGET}
 			desktopfile.files = $$PROJECTROOT/qtc_packaging/debian_harmattan/$${TARGET}.desktop
-			desktopfile.path = /usr/share/applications
+			desktopfile.path = $$[QT_INSTALL_PREFIX]/share/applications
 			icon.files = $$PROJECTROOT/qtc_packaging/debian_harmattan/$${TARGET}.png
-			icon.path = /usr/share/icons/hicolor/80x80/apps
+			icon.path = $$[QT_INSTALL_PREFIX]/share/icons/hicolor/80x80/apps
 			#debian.files = $$PROJECTROOT/qtc_packaging/harmattan/control
 		} else:maemo5 {
 			INSTALL_PREFIX = /opt/$${TARGET}
 			desktopfile.files = $$PROJECTROOT/qtc_packaging/debian_fremantle/$${TARGET}.desktop
-			desktopfile.path = /usr/share/applications/hildon
+			desktopfile.path = $$[QT_INSTALL_PREFIX]/share/applications/hildon
 			icon.files = $$PROJECTROOT/qtc_packaging/debian_fremantle/$${TARGET}.png
-			icon.path = /usr/share/icons/hicolor/64x64/apps
+			icon.path = $$[QT_INSTALL_PREFIX]/share/icons/hicolor/64x64/apps
 			#debian.files = $$PROJECTROOT/qtc_packaging/fremantle/control
 		} else {
 			desktopfile.files = $$PROJECTROOT/qtc_packaging/debian_generic/$${TARGET}.desktop
-			desktopfile.path = /usr/share/applications
+			desktopfile.path = $$[QT_INSTALL_PREFIX]/share/applications
 			icon.files = $$PROJECTROOT/qtc_packaging/debian_generic/$${TARGET}.png
-			icon.path = /usr/share/icons/hicolor/64x64/apps
+			icon.path = $$[QT_INSTALL_PREFIX]/share/icons/hicolor/64x64/apps
 			#debian.files = $$PROJECTROOT/qtc_packaging/generic/control
 		}
 		INSTALLS += desktopfile icon

--- a/examples/QMLPlayer/qtquick2applicationviewer/qtquick2applicationviewer.pri
+++ b/examples/QMLPlayer/qtquick2applicationviewer/qtquick2applicationviewer.pri
@@ -104,14 +104,14 @@ android-no-sdk {
 } else:unix {
     maemo5 {
         desktopfile.files = $${TARGET}.desktop
-        desktopfile.path = /usr/share/applications/hildon
+        desktopfile.path = $$[QT_INSTALL_PREFIX]/share/applications/hildon
         icon.files = $${TARGET}64.png
-        icon.path = /usr/share/icons/hicolor/64x64/apps
+        icon.path = $$[QT_INSTALL_PREFIX]/share/icons/hicolor/64x64/apps
     } else:!isEmpty(MEEGO_VERSION_MAJOR) {
         desktopfile.files = $${TARGET}_harmattan.desktop
-        desktopfile.path = /usr/share/applications
+        desktopfile.path = $$[QT_INSTALL_PREFIX]/share/applications
         icon.files = $${TARGET}80.png
-        icon.path = /usr/share/icons/hicolor/80x80/apps
+        icon.path = $$[QT_INSTALL_PREFIX]/share/icons/hicolor/80x80/apps
     } else { # Assumed to be a Desktop Unix
         copyCommand =
         for(deploymentfolder, DEPLOYMENTFOLDERS) {

--- a/src/libQtAV.pro
+++ b/src/libQtAV.pro
@@ -621,7 +621,7 @@ mac {
 
 unix:!mac:!cross_compile {
 icon.files = $$PWD/$${TARGET}.svg
-icon.path = /usr/share/icons/hicolor/scalable/apps
+icon.path = $$[QT_INSTALL_PREFIX]/share/icons/hicolor/scalable/apps
 INSTALLS += icon
 #debian
 DEB_INSTALL_LIST = .$$[QT_INSTALL_LIBS]/libQt*AV.so.*


### PR DESCRIPTION
This fixes `make install` (qmake) to fake root path which is needed to create packages.
When building with qmake and doing `make install` to different root path (in this case /home/max/projects/KDE/craft), operation was failing with:
```
cd install_sdk/ && ( test -e Makefile || /home/max/projects/KDE/craft/bin/qmake -o Makefile /home/max/projects/KDE/craft/download/git/libs/qtav/tools/install_sdk/install_sdk.pro 'CONFIG += no-examples no-tests' 'CONFIG -= debug' 'CONFIG += release' 'CONFIG += no-examples no-tests' 'CONFIG -= debug' 'CONFIG += release' ) && /bin/make -f Makefile install
make[1]: Entering directory '/home/max/projects/KDE/craft/build/libs/qtav/work/build/src'
...
make[2]: Entering directory '/home/max/projects/KDE/craft/build/libs/qtav/work/build/tools/install_sdk'
...
/home/max/projects/KDE/craft/bin/qmake -install qinstall /home/max/projects/KDE/craft/download/git/libs/qtav/src/QtAV.svg /usr/share/icons/hicolor/scalable/apps/QtAV.svg
/home/max/projects/KDE/craft/bin/qmake -install qinstall /home/max/projects/KDE/craft/download/git/libs/qtav/src/QtAV/Geometry.h /home/max/projects/KDE/craft/include/qt5/QtAV/Geometry.h
make[2]: Leaving directory '/home/max/projects/KDE/craft/build/libs/qtav/work/build/tools/install_sdk'
Error copying /home/max/projects/KDE/craft/download/git/libs/qtav/src/QtAV.svg to /usr/share/icons/hicolor/scalable/apps/QtAV.svg: Cannot create /usr/share/icons/hicolor/scalable/apps/QtAV.svg for output
/home/max/projects/KDE/craft/bin/qmake -install qinstall /home/max/projects/KDE/craft/download/git/libs/qtav/src/QtAV/private/OpenGLRendererBase_p.h /home/max/projects/KDE/craft/include/qt5/QtAV/5.14.1/QtAV/private/OpenGLRendererBase_p.h
make[1]: *** [Makefile.libQtAV:15750: install_icon] Error 3
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/max/projects/KDE/craft/build/libs/qtav/work/build/tools'
```