### PR TITLE
Fix android build with Qt 5.14

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -167,7 +167,6 @@ defineReplace(qtSharedLib) {
 	return($$LIB_FULLNAME)
 }
 
-
 defineReplace(qtLongName) {
   unset(LONG_NAME)
   LONG_NAME = $$1$${_OS}_$$join(TARGET_ARCH,+)$${_EXTRA}

--- a/common.pri
+++ b/common.pri
@@ -134,6 +134,7 @@ defineReplace(qtLibName) {
        }
     }
         RET = $$RET$$platformTargetSuffix()
+        qtAtLeast(5, 14):android:RET = $${RET}_$$ANDROID_TARGET_ARCH
         !win32: return($$RET)
 
 	isEmpty(2): VERSION_EXT = $$VERSION
@@ -165,6 +166,7 @@ defineReplace(qtSharedLib) {
         LIB_FULLNAME = $${QMAKE_PREFIX_SHLIB}$$member(LIB_FULLNAME, 0).$${QMAKE_EXTENSION_SHLIB} #default_post.prf
 	return($$LIB_FULLNAME)
 }
+
 
 defineReplace(qtLongName) {
   unset(LONG_NAME)


### PR DESCRIPTION
This adds the correct ABI suffix which is needed on multi-arch build with Qt 5.14 on android.
Examples still fail to compile, but I guess it's better to have the library compiled without examples than having no library at all