### PR TITLE
Avoid setting invalid framerate

### DIFF
--- a/src/AVPlayerPrivate.cpp
+++ b/src/AVPlayerPrivate.cpp
@@ -275,7 +275,9 @@ void AVPlayer::Private::initCommonStatistics(int s, Statistics::Common *st, AVCo
 #if (defined FF_API_R_FRAME_RATE && FF_API_R_FRAME_RATE) //removed in libav10
     //FIXME: which 1 should we choose? avg_frame_rate may be nan, r_frame_rate may be wrong(guessed value)
     else if (stream->r_frame_rate.den && stream->r_frame_rate.num) {
-        st->frame_rate = av_q2d(stream->r_frame_rate);
+        if (stream->r_frame_rate.num < 90000)
+            st->frame_rate = av_q2d(stream->r_frame_rate);
+
         qDebug("%d/%d", stream->r_frame_rate.num, stream->r_frame_rate.den);
     }
 #endif //FF_API_R_FRAME_RATE


### PR DESCRIPTION
In some of my RTSP streams, `r_frame_rate` was 90000/1 and this caused it to fail to load and play.
The same streams worked with ffplay each time without issues.

Adding this check to not set the `frame_rate` at all when it's invalid, fixed the issue and now it plays every time with QtAV too.