### PR TITLE
QML Player supports changing notifyInterval

### DIFF
--- a/qml/QmlAV/QmlAVPlayer.h
+++ b/qml/QmlAV/QmlAVPlayer.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
     QtAV:  Multimedia framework based on Qt and FFmpeg
     Copyright (C) 2012-2017 Wang Bin <wbsecg1@gmail.com>
 
@@ -98,6 +98,7 @@ class QmlAVPlayer : public QObject, public QQmlParserStatus
     // TODO: startPosition/stopPosition
     Q_PROPERTY(QStringList audioBackends READ audioBackends WRITE setAudioBackends NOTIFY audioBackendsChanged)
     Q_PROPERTY(QStringList supportedAudioBackends READ supportedAudioBackends)
+    Q_PROPERTY(int notifyInterval READ notifyInterval WRITE setNotifyInterval NOTIFY notifyIntervalChanged)
 public:
     enum Loop { Infinite = -1 };
     // use (1<<31)-1
@@ -280,6 +281,7 @@ public:
     QStringList supportedAudioBackends() const;
     QStringList audioBackends() const;
     void setAudioBackends(const QStringList& value);
+    int notifyInterval() const;
 
 public Q_SLOTS:
     void play();
@@ -290,7 +292,7 @@ public Q_SLOTS:
     void seek(int offset);
     void seekForward();
     void seekBackward();
-
+    void setNotifyInterval(int notifyInterval);
 Q_SIGNALS:
     void volumeChanged();
     void mutedChanged();
@@ -340,6 +342,8 @@ Q_SIGNALS:
     void statusChanged();
     void mediaObjectChanged();
     void audioBackendsChanged();
+    void notifyIntervalChanged(int notifyInterval);
+
 private Q_SLOTS:
     // connect to signals from player
     void _q_error(const QtAV::AVError& e);
@@ -397,6 +401,7 @@ private:
     QList<QuickAudioFilter*> m_afilters;
     QList<QuickVideoFilter*> m_vfilters;
     QStringList m_ao;
+    int m_notifyInterval;
 };
 
 #endif // QTAV_QML_AVPLAYER_H

--- a/qml/QmlAVPlayer.cpp
+++ b/qml/QmlAVPlayer.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
     QtAV:  Multimedia framework based on Qt and FFmpeg
     Copyright (C) 2012-2017 Wang Bin <wbsecg1@gmail.com>
 
@@ -89,6 +89,7 @@ void QmlAVPlayer::classBegin()
     connect(mpPlayer, SIGNAL(seekableChanged()), SIGNAL(seekableChanged()));
     connect(mpPlayer, SIGNAL(seekFinished(qint64)), this, SIGNAL(seekFinished()), Qt::DirectConnection);
     connect(mpPlayer, SIGNAL(bufferProgressChanged(qreal)), SIGNAL(bufferProgressChanged()));
+    connect(mpPlayer, SIGNAL(notifyIntervalChanged), SIGNAL(notifyIntervalChanged()));
     connect(this, SIGNAL(channelLayoutChanged()), SLOT(applyChannelLayout()));
     // direct connection to ensure volume() in slots is correct
     connect(mpPlayer->audio(), SIGNAL(volumeChanged(qreal)), SLOT(applyVolume()), Qt::DirectConnection);
@@ -604,6 +605,13 @@ void QmlAVPlayer::setAudioBackends(const QStringList &value)
     Q_EMIT audioBackendsChanged();
 }
 
+int QmlAVPlayer::notifyInterval() const
+{
+    if(!mpPlayer)
+        return -1;
+    return mpPlayer->notifyInterval();
+}
+
 QStringList QmlAVPlayer::supportedAudioBackends() const
 {
     return AudioOutput::backendsAvailable();
@@ -897,6 +905,14 @@ void QmlAVPlayer::seekBackward()
     mpPlayer->setSeekType(isFastSeek() ? KeyFrameSeek : AccurateSeek);
     mpPlayer->seekBackward();
 }
+
+void QmlAVPlayer::setNotifyInterval(int notifyInterval)
+{
+    if (!mpPlayer)
+        return;
+    mpPlayer->setNotifyInterval(notifyInterval);
+}
+
 
 void QmlAVPlayer::_q_error(const AVError &e)
 {

--- a/qml/Video.qml
+++ b/qml/Video.qml
@@ -1,4 +1,4 @@
-
+﻿
 import QtQuick 2.0
 import QtAV 1.7
 
@@ -91,6 +91,7 @@ Item {
     property alias internalVideoTracks: player.internalVideoTracks
     property alias internalSubtitleTracks: player.internalSubtitleTracks
     property alias internalSubtitleTrack: player.internalSubtitleTrack
+    property alias notifyInterval: player.notifyInterval
     /*** Properties of VideoOutput ***/
     /*!
         \qmlproperty enumeration Video::fillMode


### PR DESCRIPTION
Sometimes users of qmlplayer need to modify the update interval of playback progress to refresh the timeline progress bar more quickly, so I can export the notifyinterval property to the outside and set it by myself