### PR TITLE
Fixed a QmlMediaPlayer problem

### DIFF
--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -1520,6 +1520,7 @@ void AVPlayer::timerEvent(QTimerEvent *te)
     if (te->timerId() == d->timer_id) {
         // killTimer() should be in the same thread as object. kill here?
         if (isPaused()) {
+            d->clock->pause(true);
             //return; //ensure positionChanged emitted for stepForward()
         }
         // active only when playing


### PR DESCRIPTION
Fixed a QmlMediaPlayer problem: when the video file does not contain audio and autoPlay = false, the video and location are still moving after loaded, although the playback status is pause