### PR TITLE
notify player about self-pause in case of MediaEndAction_Pause triggering

### DIFF
--- a/src/AVDemuxThread.cpp
+++ b/src/AVDemuxThread.cpp
@@ -674,6 +674,7 @@ void AVDemuxThread::run()
                     break;
                 pause(true);
                 Q_EMIT requestClockPause(true);
+                Q_EMIT mediaEndActionPauseTriggered();
                 if (aqueue)
                     aqueue->blockEmpty(true);
                 if (vqueue)

--- a/src/AVDemuxThread.h
+++ b/src/AVDemuxThread.h
@@ -64,6 +64,7 @@ public:
     bool hasSeekTasks();
 Q_SIGNALS:
     void requestClockPause(bool value);
+    void mediaEndActionPauseTriggered();
     void mediaStatusChanged(QtAV::MediaStatus);
     void bufferProgressChanged(qreal);
     void seekFinished(qint64 timestamp);

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -91,6 +91,7 @@ AVPlayer::AVPlayer(QObject *parent) :
     //direct connection can not sure slot order?
     connect(d->read_thread, SIGNAL(finished()), this, SLOT(stopFromDemuxerThread()), Qt::DirectConnection);
     connect(d->read_thread, SIGNAL(requestClockPause(bool)), masterClock(), SLOT(pause(bool)), Qt::DirectConnection);
+    connect(d->read_thread, SIGNAL(mediaEndActionPauseTriggered()), this, SLOT(onMediaEndActionPauseTriggered()));
     connect(d->read_thread, SIGNAL(mediaStatusChanged(QtAV::MediaStatus)), this, SLOT(updateMediaStatus(QtAV::MediaStatus)));
     connect(d->read_thread, SIGNAL(bufferProgressChanged(qreal)), this, SIGNAL(bufferProgressChanged(qreal)));
     connect(d->read_thread, SIGNAL(seekFinished(qint64)), this, SLOT(onSeekFinished(qint64)), Qt::DirectConnection);
@@ -1402,6 +1403,16 @@ void AVPlayer::updateMediaStatus(QtAV::MediaStatus status)
         return;
     d->status = status;
     Q_EMIT mediaStatusChanged(d->status);
+}
+
+void AVPlayer::onMediaEndActionPauseTriggered()
+{
+    if(d->state == PausedState)
+        return;
+
+    d->state = PausedState;
+    Q_EMIT stateChanged(d->state);
+    Q_EMIT paused(true);
 }
 
 void AVPlayer::onSeekFinished(qint64 value)

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -616,6 +616,7 @@ private Q_SLOTS:
     void stopNotifyTimer();
     void onStarted();
     void updateMediaStatus(QtAV::MediaStatus status);
+    void onMediaEndActionPauseTriggered();
     void onSeekFinished(qint64 value);
     void onStepFinished();
     void tryClearVideoRenderers();


### PR DESCRIPTION
In current implementation player is not aware of 'automatic pause due to MediaEndAction_Pause' and there is no way to query its real state in such a case. 