### PR TITLE
Qt doesn't use debug suffix for mingw-built libraries, so QtAV shouldn't use it too

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -109,7 +109,10 @@ defineReplace(platformTargetSuffix) {
     CONFIG(debug, debug|release) {
         !debug_and_release|build_pass {
             mac: return($${suffix}_debug)
-            win32: return($${suffix}d)
+            win32: {
+                win32-g++: return($${suffix})
+                !win32-g++: return($${suffix}d)
+            }
         }
     }
     return($$suffix)


### PR DESCRIPTION
... otherwise QtAVWidgets build fails in mingw/debug build configuration