### PR TITLE
support infinite buff

### DIFF
--- a/src/AVDemuxThread.h
+++ b/src/AVDemuxThread.h
@@ -62,6 +62,11 @@ public:
     bool waitForStarted(int msec = -1);
     qint64 lastSeekPos();
     bool hasSeekTasks();
+
+    bool isAudioBufferInfinite() const;
+    void setIsAudioBufferInfinite(const bool &value);
+    bool isVideoBufferInfinite() const;
+    void setIsVideoBufferInfinite(const bool &value);
 Q_SIGNALS:
     void requestClockPause(bool value);
     void mediaEndActionPauseTriggered();
@@ -116,6 +121,8 @@ private:
     int clock_type; // change happens in different threads(direct connection)
     friend class SeekTask;
     friend class stepBackwardTask;
+    bool audioBufferInfinite;
+    bool videoBufferInfinite;
 };
 
 } //namespace QtAV

--- a/src/AVDemuxer.cpp
+++ b/src/AVDemuxer.cpp
@@ -477,6 +477,11 @@ bool AVDemuxer::readFrame()
         qWarning("[AVDemuxer] error: %s", av_err2str(ret));
         av_packet_unref(&packet); //important!
         return false;
+    } else {
+        // (under infinite buffer mode...)
+        // calling the 'av_read_frame' too fast will cause the 'av_read_frame' return 'eof', but it is not over in fact.
+        // -Gim
+        d->eof = false;
     }
     d->stream = packet.stream_index;
     //check whether the 1st frame is alreay got. emit only once

--- a/src/AVPlayer.cpp
+++ b/src/AVPlayer.cpp
@@ -471,6 +471,26 @@ void AVPlayer::setMediaEndAction(MediaEndAction value)
     d->read_thread->setMediaEndAction(value);
 }
 
+bool AVPlayer::isAudioBufferInfinite() const
+{
+    return d->read_thread->isAudioBufferInfinite();
+}
+
+void AVPlayer::setIsAudioBufferInfinite(const bool &value)
+{
+    d->read_thread->setIsAudioBufferInfinite(value);
+}
+
+bool AVPlayer::isVideoBufferInfinite() const
+{
+    return d->read_thread->isVideoBufferInfinite();
+}
+
+void AVPlayer::setIsVideoBufferInfinite(const bool &value)
+{
+    d->read_thread->setIsVideoBufferInfinite(value);
+}
+
 MediaEndAction AVPlayer::mediaEndAction() const
 {
     return d->end_action;

--- a/src/PacketBuffer.cpp
+++ b/src/PacketBuffer.cpp
@@ -116,7 +116,7 @@ bool PacketBuffer::checkEnough() const
 
 bool PacketBuffer::checkFull() const
 {
-    return buffered() >= qint64(qreal(bufferValue())*bufferMax());
+    return !checkInfinite() && buffered() >= qint64(qreal(bufferValue())*bufferMax());
 }
 
 void PacketBuffer::onPut(const Packet &p)

--- a/src/QtAV/AVPlayer.h
+++ b/src/QtAV/AVPlayer.h
@@ -413,6 +413,11 @@ public:
     MediaEndAction mediaEndAction() const;
     void setMediaEndAction(MediaEndAction value);
 
+    bool isAudioBufferInfinite() const;
+    void setIsAudioBufferInfinite(const bool &value);
+
+    bool isVideoBufferInfinite() const;
+    void setIsVideoBufferInfinite(const bool &value);
 public Q_SLOTS:
     /*!
      * \brief load


### PR DESCRIPTION
加了这些代码后，行为与原来没有区别。

但当调用AVPlayer的setIsAudioBufferInfinite与setIsVideoBufferInfinite将两个变量设置为true时，将使QtAV的播放功能有ffplay带上infbuf参数一样的行为：不再限制缓冲队列的长度。

在mdk-sdk中相关的讨论：https://github.com/wang-bin/mdk-sdk/issues/23