### PR TITLE
VideoFrameExtractor: Fix race condition in synchronous extraction mode

### DIFF
--- a/src/QtAV/VideoFrameExtractor.h
+++ b/src/QtAV/VideoFrameExtractor.h
@@ -50,6 +50,8 @@ public:
      * Extract video frames in another thread. Default is true.
      * In async mode, if current extraction is not finished, new
      * setPosition() will be ignored.
+     * If you want to disable async extraction make sure to call setAsync(false) as soon as possible (before extracting any frames or settings the source).
+     * After the first frame is extracted setAsync() has no effect.
      */
     void setAsync(bool value);
     bool async() const;


### PR DESCRIPTION
There is a race condition between the ExtractThread running [p->releaseResourceInternal()](https://github.com/wang-bin/QtAV/blob/305e54041f2292ee27ce61183fa55a9a309f01c0/src/VideoFrameExtractor.cpp#L377) (and unloading the demuxer) and the main thread calling [extract()](https://github.com/wang-bin/QtAV/blob/305e54041f2292ee27ce61183fa55a9a309f01c0/src/VideoFrameExtractor.cpp#L494) and loading the demuxer inside [checkAndOpen()](https://github.com/wang-bin/QtAV/blob/305e54041f2292ee27ce61183fa55a9a309f01c0/src/VideoFrameExtractor.cpp#L528) if run in synchronous extraction mode.

```c++
// Run in main thread
auto mpExtractor = new QtAV::VideoFrameExtractor();
mpExtractor->setAsync(false);
mpExtractor->setSource("file://whatever.mp4"); // This call will unnecessarily start the ExtractThread which will unload the demuxer in p->releaseResourceInternal()
mpExtractor->setPosition(0);
mpExtractor->extract(); // The frame extraction is only successful if the demuxer is loaded. Racing happens because the ExtractThread simultaneously unloads the demuxer while the main thread loads the demuxer in checkAndOpen()
```
The solution is not to start the ExtractThread at all if async equals false.