### PR TITLE
修复内存泄漏缺陷

### DIFF
--- a/examples/player/MainWindow.cpp
+++ b/examples/player/MainWindow.cpp
@@ -626,13 +626,17 @@ void MainWindow::changeVO(QAction *action)
     VideoRendererId vid = (VideoRendererId)action->data().toInt();
     VideoRenderer *vo = VideoRenderer::create(vid);
     if (vo && vo->isAvailable()) {
-        if (!setRenderer(vo))
+        if (setRenderer(vo))
+            return;
+        else
             action->toggle();
     } else {
         action->toggle(); //check state changes if clicked
         QMessageBox::critical(0, QString::fromLatin1("QtAV"), tr("not availabe on your platform!"));
-        return;
     }
+
+    if (vo)
+        delete vo;
 }
 
 void MainWindow::processPendingActions()


### PR DESCRIPTION
设置渲染引擎失败时，没有释放无效的渲染引擎，引发内存泄漏。